### PR TITLE
Avoid building kustomize in unittests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ build:
 all: test manager
 
 # Run tests
-test: generate fmt vet manifests
+test: generate fmt vet
 	go test ./pkg/... ./cmd/... -coverprofile cover.out
 
 # Build manager binary


### PR DESCRIPTION
This would not require kustomize to run unittests. Hopefully this would fix https://openshift-gce-devel.appspot.com/build/origin-ci-test/pr-logs/pull/openshift_release/3055/rehearse-3055-pull-ci-openshift-cluster-api-provider-baremetal-master-unit/4