### PR TITLE
Fix import for runtime.Scheme

### DIFF
--- a/pkg/apis/baremetal/v1alpha1/register.go
+++ b/pkg/apis/baremetal/v1alpha1/register.go
@@ -26,7 +26,7 @@ package v1alpha1
 
 import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/runtime/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
 var (


### PR DESCRIPTION
The latest beta of controller-runtime 0.2 fixed this breakage by adding
a typedef for Builder pointing to scheme.Builder, however this is not
available in vendored version in the installer. Changing the import
works with all betas of controller-runtime 0.2.

Installer builds are failing and I cannot rebase:

```
+ go build -ldflags ' -X github.com/openshift-metalkube/kni-installer/pkg/version.Raw=unreleased-master-1395-gaf434a07b8c96299aac80b88fe6e403c2a5e62ad-dirty -X github.com/openshift-metalkube/kni-installer/pkg/version.Commit=af434a07b8c96299aac80b88fe6e403c2a5e62ad -s -w' -tags 'libvirt release' -o bin/kni-install ./cmd/kni-install
# github.com/openshift-metalkube/kni-installer/vendor/github.com/metal3-io/cluster-api-provider-baremetal/pkg/apis/baremetal/v1alpha1
vendor/github.com/metal3-io/cluster-api-provider-baremetal/pkg/apis/baremetal/v1alpha1/register.go:37:19: undefined: scheme.Builder
```

This is the fix that is not available:
   https://github.com/kubernetes-sigs/controller-runtime/blob/release-0.2/pkg/runtime/scheme/scheme.go#L29

So we need to pull from this import:
    https://github.com/kubernetes-sigs/controller-runtime/blob/release-0.2/pkg/scheme/scheme.go#L64