### PR TITLE
Set NodeInternalDNS address on Machine.

### DIFF
--- a/pkg/cloud/baremetal/actuators/machine/actuator.go
+++ b/pkg/cloud/baremetal/actuators/machine/actuator.go
@@ -531,6 +531,10 @@ func (a *Actuator) nodeAddresses(host *bmh.BareMetalHost) ([]corev1.NodeAddress,
 			Type:    corev1.NodeHostName,
 			Address: host.Status.HardwareDetails.Hostname,
 		})
+		addrs = append(addrs, corev1.NodeAddress{
+			Type:    corev1.NodeInternalDNS,
+			Address: host.Status.HardwareDetails.Hostname,
+		})
 	}
 
 	return addrs, nil


### PR DESCRIPTION
The code already set the NodeHostname address type.  This patch sets
that same value as the NodeInternalDNS.

I ran into a component (openshift/cluster-machine-approver) that
expected a NodeInternalDNS field to be set on the Machine with the
hostname.