### PR TITLE
docs/api: Fix curly quotes in YAML examples

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -59,7 +59,7 @@ spec:
         matchExpressions:
           key: key2
           operator: in
-          values: {‘abc’, ‘123’, ‘value2’}
+          values: {'abc', '123', 'value2'}
   versions:
     kubelet: ""
 ```
@@ -143,7 +143,7 @@ spec:
         matchExpressions:
           - key: key3
             operator: in
-            values: [‘a’, ‘b’, ‘c’]
+            values: ['a', 'b', 'c']
 ```
 
 Example 3: Only consider `BareMetalHost` with `key1` set to `value1` AND `key2`
@@ -160,5 +160,5 @@ spec:
         matchExpressions:
           - key: key3
             operator: in
-            values: [‘a’, ‘b’, ‘c’]
+            values: ['a', 'b', 'c']
 ```


### PR DESCRIPTION
Originally from ba87bda4de (#74).

Generated with:

```console
$ sed -i "s/‘/'/g;s/’/'/g" docs/api.md
```