### PR TITLE
openshift: Set instance-state and instance-type.

### DIFF
--- a/pkg/cloud/baremetal/actuators/machine/actuator_test.go
+++ b/pkg/cloud/baremetal/actuators/machine/actuator_test.go
@@ -1277,7 +1277,7 @@ func TestUpdateMachineStatus(t *testing.T) {
 			t.Error(err)
 		}
 
-		err = actuator.updateMachineStatus(context.TODO(), tc.Machine, tc.Host)
+		err = actuator.updateMachine(context.TODO(), tc.Machine, tc.Host)
 		if err != nil {
 			t.Errorf("unexpected error %v", err)
 		}


### PR DESCRIPTION
This patch sets some OpenShift specific information on the Machine.

The instance-state annotation is set to the provisioning status of the
underlying BareMetalHost. The instance-type label is set to the
hardware profile of the underlying BareMetalHost.  These seem to be
the most relevant pieces of information for the intent of these
fields.

With these changes in place, some additional information will be
printed out when you run "oc get machines".  For example, here is the
output in my dev cluster.  Note that type is still blank, because the
hardware profile is blank in this case.

```
    $ oc get machines -n openshift-machine-api
    NAME                    STATE                    TYPE   REGION   ZONE   AGE
    ostest-master-0         externally_provisioned                          4d
    ostest-master-1         externally_provisioned                          4d
    ostest-master-2         externally_provisioned                          4d
    ostest-worker-0-vzkx4   inspecting                                      3d23h
```