### PR TITLE
fixes broken `make manifests`, which was also breaking `make unit`.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ manifests:
 	go run vendor/sigs.k8s.io/controller-tools/cmd/controller-gen/main.go all
 	kustomize build config/ > provider-components.yaml
 	echo "---" >> provider-components.yaml
-	cd vendor && kustomize build github.com/openshift/cluster-api/config >> ../provider-components.yaml
+	kustomize build vendor/github.com/openshift/cluster-api/config >> provider-components.yaml
 
 # Run go fmt against code
 fmt:


### PR DESCRIPTION
kustomize was interpreting the path argument
`github.com/openshift/cluster-api/config` as a URL instead of a relative file
path. It was doing something with git to retrieve files from github, put them
in a temporary directory (hence the confusing error message about a directory
in /tmp/), then failing to find what it expected.

fixes #48