### PR TITLE
Delete Machine when BareMetalHost is deleted

### DIFF
--- a/pkg/cloud/baremetal/actuators/machine/actuator.go
+++ b/pkg/cloud/baremetal/actuators/machine/actuator.go
@@ -211,6 +211,15 @@ func (a *Actuator) Update(ctx context.Context, cluster *clusterv1.Cluster, machi
 		return err
 	}
 	if host == nil {
+		// When finalizer for BHM is removed but an error occur before
+		// the Machine is deleted below in the StateDeleting block, the
+		// Machine should be deleted when no host is found.
+		log.Print("Deleting machine associated with no host: ", machine.Name)
+		a.client.Delete(ctx, machine)
+		if err != nil && !errors.IsNotFound(err) {
+			return err
+		}
+		log.Print("Deleted machine associated with no host: ", machine.Name)
 		return fmt.Errorf("host not found for machine %s", machine.Name)
 	}
 

--- a/pkg/cloud/baremetal/actuators/machine/actuator.go
+++ b/pkg/cloud/baremetal/actuators/machine/actuator.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	bmh "github.com/metal3-io/baremetal-operator/pkg/apis/metal3/v1alpha1"
+	"github.com/metal3-io/baremetal-operator/pkg/utils"
 	bmv1alpha1 "github.com/metal3-io/cluster-api-provider-baremetal/pkg/apis/baremetal/v1alpha1"
 	clusterv1 "github.com/openshift/cluster-api/pkg/apis/cluster/v1alpha1"
 	"github.com/openshift/cluster-api/pkg/apis/machine/common"
@@ -119,6 +120,10 @@ func (a *Actuator) Create(ctx context.Context, cluster *clusterv1.Cluster, machi
 		log.Printf("Machine %s already associated with host %s", machine.Name, host.Name)
 	}
 
+	// Add a finalizer for the BMH. This will allow us to delete
+	// the Machine when the BMH is deleted.
+	host.Finalizers = append(host.Finalizers, machinev1.MachineFinalizer)
+
 	err = a.setHostSpec(ctx, host, machine, config)
 	if err != nil {
 		return err
@@ -205,6 +210,35 @@ func (a *Actuator) Update(ctx context.Context, cluster *clusterv1.Cluster, machi
 	}
 	if host == nil {
 		return fmt.Errorf("host not found for machine %s", machine.Name)
+	}
+
+	// Delete Machine when BareMetalHost is deleted.
+	// This is to ensure the MachineSet creates a new Machine
+	// containing the latest ProviderSpec.
+	if host.Status.Provisioning.State == "deleting" {
+		log.Print("Removing consumerRef for host: ", host.Name)
+		host.Spec.ConsumerRef = nil
+		err = a.client.Update(ctx, host)
+		if err != nil && !errors.IsNotFound(err) {
+			return err
+		}
+
+		log.Print("Deleting machine associated with host: ", host.Name)
+		a.client.Delete(ctx, machine)
+		if err != nil && !errors.IsNotFound(err) {
+			return err
+		}
+		log.Print("Deleted machine associated with host: ", host.Name)
+
+		log.Print("Removing finalizer for host: ", host.Name)
+		host.Finalizers = utils.FilterStringFromList(
+			host.Finalizers, machinev1.MachineFinalizer)
+		err = a.client.Update(ctx, host)
+		if err != nil && !errors.IsNotFound(err) {
+			return err
+		}
+		log.Print("Removed finalizer for host ", host.Name)
+		return nil
 	}
 
 	err = a.ensureAnnotation(ctx, machine, host)

--- a/pkg/cloud/baremetal/actuators/machine/actuator.go
+++ b/pkg/cloud/baremetal/actuators/machine/actuator.go
@@ -214,12 +214,12 @@ func (a *Actuator) Update(ctx context.Context, cluster *clusterv1.Cluster, machi
 		// When finalizer for BHM is removed but an error occur before
 		// the Machine is deleted below in the StateDeleting block, the
 		// Machine should be deleted when no host is found.
-		log.Print("Deleting machine associated with no host: ", machine.Name)
+		log.Print("Deleting machine whose associated host is gone: ", machine.Name)
 		a.client.Delete(ctx, machine)
 		if err != nil && !errors.IsNotFound(err) {
 			return err
 		}
-		log.Print("Deleted machine associated with no host: ", machine.Name)
+		log.Print("Deleted machine whose associated host is gone: ", machine.Name)
 		return fmt.Errorf("host not found for machine %s", machine.Name)
 	}
 
@@ -235,15 +235,15 @@ func (a *Actuator) Update(ctx context.Context, cluster *clusterv1.Cluster, machi
 			if err != nil && !errors.IsNotFound(err) {
 				return err
 			}
-			log.Print("Removed finalizer for host ", host.Name)
+			log.Print("Removed finalizer for host: ", host.Name)
 		}
 
-		log.Print("Deleting machine associated with host: ", host.Name)
+		log.Print("Deleting machine whose associated host is gone: ", machine.Name)
 		a.client.Delete(ctx, machine)
 		if err != nil && !errors.IsNotFound(err) {
 			return err
 		}
-		log.Print("Deleted machine associated with host: ", host.Name)
+		log.Print("Deleted machine whose associated host is gone: ", machine.Name)
 		return nil
 	}
 

--- a/pkg/cloud/baremetal/actuators/machine/actuator.go
+++ b/pkg/cloud/baremetal/actuators/machine/actuator.go
@@ -215,7 +215,7 @@ func (a *Actuator) Update(ctx context.Context, cluster *clusterv1.Cluster, machi
 	// Delete Machine when BareMetalHost is deleted.
 	// This is to ensure the MachineSet creates a new Machine
 	// containing the latest ProviderSpec.
-	if host.Status.Provisioning.State == "deleting" {
+	if host.Status.Provisioning.State == bmh.StateDeleting {
 		log.Print("Removing consumerRef for host: ", host.Name)
 		host.Spec.ConsumerRef = nil
 		err = a.client.Update(ctx, host)

--- a/pkg/cloud/baremetal/actuators/machine/actuator.go
+++ b/pkg/cloud/baremetal/actuators/machine/actuator.go
@@ -235,17 +235,6 @@ func (a *Actuator) Update(ctx context.Context, cluster *clusterv1.Cluster, machi
 			return err
 		}
 		log.Print("Deleted machine associated with host: ", host.Name)
-
-		if host.Spec.ConsumerRef != nil {
-			log.Print("Removing consumerRef for host: ", host.Name)
-			host.Spec.ConsumerRef = nil
-			err = a.client.Update(ctx, host)
-			if err != nil && !errors.IsNotFound(err) {
-				return err
-			}
-			log.Print("Removed consumerRef for host: ", host.Name)
-		}
-
 		return nil
 	}
 

--- a/pkg/cloud/baremetal/actuators/machine/actuator_test.go
+++ b/pkg/cloud/baremetal/actuators/machine/actuator_test.go
@@ -2,7 +2,6 @@ package machine
 
 import (
 	"context"
-	"reflect"
 	"testing"
 	"time"
 
@@ -1509,7 +1508,6 @@ func TestDeleteOfBareMetalHostDeletesMachine(t *testing.T) {
 		Host                  *bmh.BareMetalHost
 		Machine               *machinev1.Machine
 		ExpectedMachineExists bool
-		ExpectedConsumerRef   *corev1.ObjectReference
 	}{
 		{
 			CaseName: "machine should not be deleted",
@@ -1544,12 +1542,6 @@ func TestDeleteOfBareMetalHostDeletesMachine(t *testing.T) {
 				Status: machinev1.MachineStatus{},
 			},
 			ExpectedMachineExists: true,
-			ExpectedConsumerRef: &corev1.ObjectReference{
-				Name:       "mymachine1",
-				Namespace:  "myns",
-				Kind:       "Machine",
-				APIVersion: machinev1.SchemeGroupVersion.String(),
-			},
 		},
 		{
 			CaseName: "machine should be deleted",
@@ -1584,7 +1576,6 @@ func TestDeleteOfBareMetalHostDeletesMachine(t *testing.T) {
 				Status: machinev1.MachineStatus{},
 			},
 			ExpectedMachineExists: false,
-			ExpectedConsumerRef:   nil,
 		},
 	}
 
@@ -1628,17 +1619,6 @@ func TestDeleteOfBareMetalHostDeletesMachine(t *testing.T) {
 				if tc.ExpectedMachineExists != result {
 					t.Errorf("ExpectedMachineExists: %v, found %v", tc.ExpectedMachineExists, result)
 				}
-			}
-
-			hostKey := client.ObjectKey{
-				Name:      tc.Host.Name,
-				Namespace: tc.Host.Namespace,
-			}
-			host := bmh.BareMetalHost{}
-			c.Get(context.TODO(), hostKey, &host)
-
-			if reflect.DeepEqual(tc.ExpectedConsumerRef, host.Spec.ConsumerRef) == false {
-				t.Errorf("expected Host consumerRef: %v, found %v", tc.ExpectedConsumerRef, host.Spec.ConsumerRef)
 			}
 		}
 	}

--- a/pkg/cloud/baremetal/actuators/machine/actuator_test.go
+++ b/pkg/cloud/baremetal/actuators/machine/actuator_test.go
@@ -2,6 +2,7 @@ package machine
 
 import (
 	"context"
+	"reflect"
 	"testing"
 	"time"
 
@@ -12,6 +13,7 @@ import (
 	machinev1 "github.com/openshift/cluster-api/pkg/apis/machine/v1beta1"
 	clustererror "github.com/openshift/cluster-api/pkg/controller/error"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -1492,6 +1494,151 @@ func TestNodeAddresses(t *testing.T) {
 		for i, address := range expectedNodeAddresses {
 			if address != nodeAddresses[i] {
 				t.Errorf("expected Address %v, found %v", address, nodeAddresses[i])
+			}
+		}
+	}
+}
+
+func TestDeleteOfBareMetalHostDeletesMachine(t *testing.T) {
+	scheme := runtime.NewScheme()
+	clusterapis.AddToScheme(scheme)
+	bmoapis.AddToScheme(scheme)
+
+	testCases := []struct {
+		CaseName              string
+		Host                  *bmh.BareMetalHost
+		Machine               *machinev1.Machine
+		ExpectedMachineExists bool
+		ExpectedConsumerRef   *corev1.ObjectReference
+	}{
+		{
+			CaseName: "machine should not be deleted",
+			Host: &bmh.BareMetalHost{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "myhost1",
+					Namespace: "myns",
+				},
+				Spec: bmh.BareMetalHostSpec{
+					ConsumerRef: &corev1.ObjectReference{
+						Name:       "mymachine1",
+						Namespace:  "myns",
+						Kind:       "Machine",
+						APIVersion: machinev1.SchemeGroupVersion.String(),
+					},
+				},
+				Status: bmh.BareMetalHostStatus{
+					HardwareProfile: "dell",
+					Provisioning: bmh.ProvisionStatus{
+						State: "ready",
+					},
+				},
+			},
+			Machine: &machinev1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "mymachine1",
+					Namespace: "myns",
+					Annotations: map[string]string{
+						HostAnnotation: "myns/myhost1",
+					},
+				},
+				Status: machinev1.MachineStatus{},
+			},
+			ExpectedMachineExists: true,
+			ExpectedConsumerRef: &corev1.ObjectReference{
+				Name:       "mymachine1",
+				Namespace:  "myns",
+				Kind:       "Machine",
+				APIVersion: machinev1.SchemeGroupVersion.String(),
+			},
+		},
+		{
+			CaseName: "machine should be deleted",
+			Host: &bmh.BareMetalHost{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "myhost2",
+					Namespace: "myns",
+				},
+				Spec: bmh.BareMetalHostSpec{
+					ConsumerRef: &corev1.ObjectReference{
+						Name:       "mymachine2",
+						Namespace:  "myns",
+						Kind:       "Machine",
+						APIVersion: machinev1.SchemeGroupVersion.String(),
+					},
+				},
+				Status: bmh.BareMetalHostStatus{
+					HardwareProfile: "dell",
+					Provisioning: bmh.ProvisionStatus{
+						State: "deleting",
+					},
+				},
+			},
+			Machine: &machinev1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "mymachine2",
+					Namespace: "myns",
+					Annotations: map[string]string{
+						HostAnnotation: "myns/myhost2",
+					},
+				},
+				Status: machinev1.MachineStatus{},
+			},
+			ExpectedMachineExists: false,
+			ExpectedConsumerRef:   nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		c := fakeclient.NewFakeClientWithScheme(scheme)
+		if tc.Machine != nil {
+			c.Create(context.TODO(), tc.Machine)
+		}
+		if tc.Host != nil {
+			c.Create(context.TODO(), tc.Host)
+		}
+		actuator, err := NewActuator(ActuatorParams{
+			Client: c,
+		})
+		if err != nil {
+			t.Error(err)
+		}
+
+		err = actuator.Update(context.TODO(), nil, tc.Machine)
+		if err != nil {
+			t.Errorf("unexpected error %v", err)
+		}
+
+		if &tc.Machine != nil {
+			key := client.ObjectKey{
+				Name:      tc.Machine.Name,
+				Namespace: tc.Machine.Namespace,
+			}
+			machine := machinev1.Machine{}
+
+			err = c.Get(context.TODO(), key, &machine)
+			if tc.ExpectedMachineExists == false {
+				if !errors.IsNotFound(err) {
+					t.Errorf("Expected machine to not exist but received error: %v", err)
+				}
+			} else {
+				result, err := actuator.Exists(context.TODO(), nil, tc.Machine)
+				if err != nil {
+					t.Error(err)
+				}
+				if tc.ExpectedMachineExists != result {
+					t.Errorf("ExpectedMachineExists: %v, found %v", tc.ExpectedMachineExists, result)
+				}
+			}
+
+			hostKey := client.ObjectKey{
+				Name:      tc.Host.Name,
+				Namespace: tc.Host.Namespace,
+			}
+			host := bmh.BareMetalHost{}
+			c.Get(context.TODO(), hostKey, &host)
+
+			if reflect.DeepEqual(tc.ExpectedConsumerRef, host.Spec.ConsumerRef) == false {
+				t.Errorf("expected Host consumerRef: %v, found %v", tc.ExpectedConsumerRef, host.Spec.ConsumerRef)
 			}
 		}
 	}


### PR DESCRIPTION
This is to ensure a new Machine is created by the MachineSet
controller and that it will contain the latest ProviderSpec.

Signed-off-by: Richard Su rwsu@redhat.com