### PR TITLE
adds auto-scaling for MachineSet based on number of BareMetalHosts

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1074,6 +1074,7 @@
     "sigs.k8s.io/controller-runtime/pkg/envtest",
     "sigs.k8s.io/controller-runtime/pkg/handler",
     "sigs.k8s.io/controller-runtime/pkg/manager",
+    "sigs.k8s.io/controller-runtime/pkg/predicate",
     "sigs.k8s.io/controller-runtime/pkg/reconcile",
     "sigs.k8s.io/controller-runtime/pkg/runtime/log",
     "sigs.k8s.io/controller-runtime/pkg/runtime/signals",

--- a/README.md
+++ b/README.md
@@ -20,3 +20,19 @@ For more information about this actuator and related repositories, see
 
 See the [API Documentation](docs/api.md) for details about the `providerSpec`
 API used with this `cluster-api` provider.
+
+## MachineSet Scaling
+
+If you would like a MachineSet to be automatically scaled to the number of
+matching BareMetalHosts, annotate that MachineSet with key
+`metal3.io/autoscale-to-hosts` and any value.
+
+When reconciling a MachineSet, the controller will count all of the
+BareMetalHosts that either:
+* match the MachineSet's `Spec.Template.Spec.ProviderSpec.HostSelector` and
+  have a ConsumerRef that is `nil`
+* has a ConsumerRef that references a Machine that is part of the MachineSet
+
+This ensures that in case a BareMetalHost has previously been consumed by a
+Machine, but either labels or selectors have since been changed, it will
+continue to get counted with the MachineSet that its Machine belongs to.

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -25,6 +25,7 @@ import (
 	bmoapis "github.com/metal3-io/baremetal-operator/pkg/apis"
 	"github.com/metal3-io/cluster-api-provider-baremetal/pkg/apis"
 	"github.com/metal3-io/cluster-api-provider-baremetal/pkg/cloud/baremetal/actuators/machine"
+	"github.com/metal3-io/cluster-api-provider-baremetal/pkg/controller"
 	"github.com/metal3-io/cluster-api-provider-baremetal/pkg/manager/wrapper"
 	clusterapis "github.com/openshift/cluster-api/pkg/apis"
 	capimachine "github.com/openshift/cluster-api/pkg/controller/machine"
@@ -96,6 +97,11 @@ func main() {
 
 	// the manager wrapper will add an extra Watch to the controller
 	capimachine.AddWithActuator(wrapper.New(mgr), machineActuator)
+
+	if err := controller.AddToManager(mgr); err != nil {
+		log.Error(err, "Failed to add controller to manager")
+		os.Exit(1)
+	}
 
 	if err := mgr.Start(signals.SetupSignalHandler()); err != nil {
 		entryLog.Error(err, "unable to run manager")

--- a/config/rbac/rbac_role.yaml
+++ b/config/rbac/rbac_role.yaml
@@ -49,18 +49,15 @@ rules:
   - update
   - patch
 - apiGroups:
-  - baremetal.cluster.k8s.io
+  - cluster.k8s.io
   resources:
-  - baremetalmachineproviderspecs
-  - baremetalmachineproviderstatuses
+  - machinesets
   verbs:
   - get
   - list
   - watch
-  - create
   - update
   - patch
-  - delete
 - apiGroups:
   - admissionregistration.k8s.io
   resources:

--- a/pkg/cloud/baremetal/actuators/machine/actuator.go
+++ b/pkg/cloud/baremetal/actuators/machine/actuator.go
@@ -107,7 +107,7 @@ func (a *Actuator) Create(ctx context.Context, cluster *clusterv1.Cluster, machi
 
 	// none found, so try to choose one
 	if host == nil {
-		host, err = a.chooseHost(ctx, machine, config)
+		host, err = a.chooseHost(ctx, machine)
 		if err != nil {
 			return err
 		}
@@ -324,12 +324,41 @@ func (a *Actuator) getHost(ctx context.Context, machine *machinev1.Machine) (*bm
 	return &host, nil
 }
 
+// SelectorFromProviderSpec returns a selector that can be used to determine if
+// a BareMetalHost matches a Machine.
+func SelectorFromProviderSpec(providerspec *machinev1.ProviderSpec) (labels.Selector, error) {
+	config, err := configFromProviderSpec(*providerspec)
+	if err != nil {
+		log.Printf("Error reading ProviderSpec: %s", err.Error())
+		return nil, err
+	}
+	selector := labels.NewSelector()
+	var reqs labels.Requirements
+	for labelKey, labelVal := range config.HostSelector.MatchLabels {
+		r, err := labels.NewRequirement(labelKey, selection.Equals, []string{labelVal})
+		if err != nil {
+			log.Printf("Failed to create MatchLabel requirement: %v", err)
+			return nil, err
+		}
+		reqs = append(reqs, *r)
+	}
+	for _, req := range config.HostSelector.MatchExpressions {
+		lowercaseOperator := selection.Operator(strings.ToLower(string(req.Operator)))
+		r, err := labels.NewRequirement(req.Key, lowercaseOperator, req.Values)
+		if err != nil {
+			log.Printf("Failed to create MatchExpression requirement: %v", err)
+			return nil, err
+		}
+		reqs = append(reqs, *r)
+	}
+	selector = selector.Add(reqs...)
+	return selector, nil
+}
+
 // chooseHost iterates through known hosts and returns one that can be
 // associated with the machine. It searches all hosts in case one already has an
 // association with this machine.
-func (a *Actuator) chooseHost(ctx context.Context, machine *machinev1.Machine,
-	config *bmv1alpha1.BareMetalMachineProviderSpec) (*bmh.BareMetalHost, error) {
-
+func (a *Actuator) chooseHost(ctx context.Context, machine *machinev1.Machine) (*bmh.BareMetalHost, error) {
 	// get list of BMH
 	hosts := bmh.BareMetalHostList{}
 	opts := &client.ListOptions{
@@ -343,31 +372,12 @@ func (a *Actuator) chooseHost(ctx context.Context, machine *machinev1.Machine,
 
 	// Using the label selector on ListOptions above doesn't seem to work.
 	// I think it's because we have a local cache of all BareMetalHosts.
-	labelSelector := labels.NewSelector()
-	var reqs labels.Requirements
-	for labelKey, labelVal := range config.HostSelector.MatchLabels {
-		log.Printf("Adding requirement to match label: '%s' == '%s'", labelKey, labelVal)
-		r, err := labels.NewRequirement(labelKey, selection.Equals, []string{labelVal})
-		if err != nil {
-			log.Printf("Failed to create MatchLabel requirement, not choosing host: %v", err)
-			return nil, err
-		}
-		reqs = append(reqs, *r)
+	labelSelector, err := SelectorFromProviderSpec(&machine.Spec.ProviderSpec)
+	if err != nil {
+		return nil, err
 	}
-	for _, req := range config.HostSelector.MatchExpressions {
-		log.Printf("Adding requirement to match label: '%s' %s '%s'", req.Key, req.Operator, req.Values)
-		lowercaseOperator := selection.Operator(strings.ToLower(string(req.Operator)))
-		r, err := labels.NewRequirement(req.Key, lowercaseOperator, req.Values)
-		if err != nil {
-			log.Printf("Failed to create MatchExpression requirement, not choosing host: %v", err)
-			return nil, err
-		}
-		reqs = append(reqs, *r)
-	}
-	labelSelector = labelSelector.Add(reqs...)
 
 	availableHosts := []*bmh.BareMetalHost{}
-
 	for i, host := range hosts.Items {
 		if host.Available() {
 			if labelSelector.Matches(labels.Set(host.ObjectMeta.Labels)) {

--- a/pkg/cloud/baremetal/actuators/machine/actuator_test.go
+++ b/pkg/cloud/baremetal/actuators/machine/actuator_test.go
@@ -131,6 +131,7 @@ func TestChooseHost(t *testing.T) {
 			},
 			Hosts:            []runtime.Object{&host2, &host1},
 			ExpectedHostName: host2.Name,
+			Config:           config,
 		},
 		{
 			// should ignore discoveredHost and pick host2, which lacks a ConsumerRef
@@ -146,6 +147,7 @@ func TestChooseHost(t *testing.T) {
 			},
 			Hosts:            []runtime.Object{&discoveredHost, &host2, &host1},
 			ExpectedHostName: host2.Name,
+			Config:           config,
 		},
 		{
 			// should pick host3, which already has a matching ConsumerRef
@@ -164,6 +166,7 @@ func TestChooseHost(t *testing.T) {
 			},
 			Hosts:            []runtime.Object{&host1, &host3, &host2},
 			ExpectedHostName: host3.Name,
+			Config:           config,
 		},
 		{
 			// should not pick a host, because two are already taken, and the third is in
@@ -183,6 +186,7 @@ func TestChooseHost(t *testing.T) {
 			},
 			Hosts:            []runtime.Object{&host1, &host3, &host4},
 			ExpectedHostName: "",
+			Config:           config,
 		},
 		{
 			// Can choose hosts with a label, even without a label selector
@@ -201,6 +205,7 @@ func TestChooseHost(t *testing.T) {
 			},
 			Hosts:            []runtime.Object{&host_with_label},
 			ExpectedHostName: host_with_label.Name,
+			Config:           config,
 		},
 		{
 			// Choose the host with the right label
@@ -308,11 +313,13 @@ func TestChooseHost(t *testing.T) {
 		if err != nil {
 			t.Errorf("%v", err)
 		}
-		cfg := tc.Config
-		if cfg == nil {
-			cfg = config
+		pspec, err := yaml.Marshal(&tc.Config)
+		if err != nil {
+			t.Logf("could not marshal BareMetalMachineProviderSpec: %v", err)
+			t.FailNow()
 		}
-		result, err := actuator.chooseHost(context.TODO(), &tc.Machine, cfg)
+		tc.Machine.Spec.ProviderSpec = machinev1.ProviderSpec{Value: &runtime.RawExtension{Raw: pspec}}
+		result, err := actuator.chooseHost(context.TODO(), &tc.Machine)
 		if tc.ExpectedHostName == "" {
 			if result != nil {
 				t.Error("found host when none should have been available")

--- a/pkg/controller/add_machineset.go
+++ b/pkg/controller/add_machineset.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Kubernetes authors.
+Copyright 2019 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,15 +17,10 @@ limitations under the License.
 package controller
 
 import (
-	"github.com/metal3-io/cluster-api-provider-baremetal/pkg/cloud/baremetal/actuators/machine"
-	capimachine "github.com/openshift/cluster-api/pkg/controller/machine"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"github.com/metal3-io/cluster-api-provider-baremetal/pkg/controller/machineset"
 )
 
-//+kubebuilder:rbac:groups=baremetal.cluster.k8s.io,resources=baremetalmachineproviderspecs;baremetalmachineproviderstatuses,verbs=get;list;watch;create;update;patch;delete
 func init() {
 	// AddToManagerFuncs is a list of functions to create controllers and add them to a manager.
-	AddToManagerFuncs = append(AddToManagerFuncs, func(m manager.Manager) error {
-		return capimachine.AddWithActuator(m, &machine.Actuator{})
-	})
+	AddToManagerFuncs = append(AddToManagerFuncs, machineset.Add)
 }

--- a/pkg/controller/machineset/machineset_controller.go
+++ b/pkg/controller/machineset/machineset_controller.go
@@ -1,0 +1,208 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package machineset
+
+import (
+	"context"
+	"fmt"
+
+	bmh "github.com/metal3-io/baremetal-operator/pkg/apis/metal3/v1alpha1"
+	actuator "github.com/metal3-io/cluster-api-provider-baremetal/pkg/cloud/baremetal/actuators/machine"
+	machinev1beta1 "github.com/openshift/cluster-api/pkg/apis/machine/v1beta1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+var log = logf.Log.WithName("machineset-controller")
+
+// errConsumerNotFound indicates that the Machine referenced in a BareMetalHost's
+// Spec.ConsumerRef cannot be found. That's an unexpected state, so we don't
+// want to do any scaling until it gets resolved.
+var errConsumerNotFound = fmt.Errorf("consuming Machine not found")
+
+// Add creates a new MachineSet Controller and adds it to the Manager with default RBAC. The Manager will set fields on the Controller
+// and Start it when the Manager is Started.
+func Add(mgr manager.Manager) error {
+	return add(mgr, newReconciler(mgr))
+}
+
+// newReconciler returns a new reconcile.Reconciler
+func newReconciler(mgr manager.Manager) reconcile.Reconciler {
+	return &ReconcileMachineSet{Client: mgr.GetClient(), scheme: mgr.GetScheme()}
+}
+
+// add adds a new Controller to mgr with r as the reconcile.Reconciler
+func add(mgr manager.Manager, r reconcile.Reconciler) error {
+	// Create a new controller
+	c, err := controller.New("machineset-controller", mgr, controller.Options{Reconciler: r})
+	if err != nil {
+		return err
+	}
+
+	// Watch for changes to MachineSet
+	err = c.Watch(&source.Kind{Type: &machinev1beta1.MachineSet{}},
+		&handler.EnqueueRequestForObject{}, predicate.ResourceVersionChangedPredicate{})
+	if err != nil {
+		return err
+	}
+
+	mapper := msmapper{client: mgr.GetClient()}
+	err = c.Watch(&source.Kind{Type: &bmh.BareMetalHost{}},
+		&handler.EnqueueRequestsFromMapFunc{ToRequests: &mapper}, predicate.ResourceVersionChangedPredicate{})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var _ reconcile.Reconciler = &ReconcileMachineSet{}
+
+// ReconcileMachineSet reconciles a MachineSet object
+type ReconcileMachineSet struct {
+	client.Client
+	scheme *runtime.Scheme
+}
+
+// Reconcile reads that state of the cluster for a MachineSet object and makes changes based on the state read
+// and what is in the MachineSet.Spec
+// Automatically generate RBAC rules to allow the Controller to read and write Deployments
+// +kubebuilder:rbac:groups=cluster.k8s.io,resources=machinesets,verbs=get;list;watch;update;patch
+func (r *ReconcileMachineSet) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	log := log.WithValues("MachineSet", request.NamespacedName.String())
+	ctx := context.TODO()
+	// Fetch the MachineSet instance
+	instance := &machinev1beta1.MachineSet{}
+	err := r.Get(ctx, request.NamespacedName, instance)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// Object not found, return.  Created objects are automatically garbage collected.
+			// For additional cleanup logic use finalizers.
+			return reconcile.Result{}, nil
+		}
+		// Error reading the object - requeue the request.
+		return reconcile.Result{}, err
+	}
+
+	// Don't take action if the annotation is not present
+	annotations := instance.ObjectMeta.GetAnnotations()
+	if annotations == nil {
+		return reconcile.Result{}, nil
+	}
+	_, present := annotations[AutoScaleAnnotation]
+	if !present {
+		return reconcile.Result{}, nil
+	}
+
+	// Make sure the MachineSet has a non-empty selector.
+	msselector, err := metav1.LabelSelectorAsSelector(&instance.Spec.Selector)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	if msselector.Empty() {
+		// The cluster-api machinesetcontroller expects every MachineSet to have
+		// its Selector set.
+		log.Info("MachineSet has empty selector, which is unexpected. Will not attempt scaling.")
+		return reconcile.Result{}, nil
+	}
+
+	hostselector, err := actuator.SelectorFromProviderSpec(&instance.Spec.Template.Spec.ProviderSpec)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	hosts := &bmh.BareMetalHostList{}
+	opts := &client.ListOptions{
+		Namespace: instance.Namespace,
+	}
+
+	err = r.List(ctx, hosts, client.UseListOptions(opts))
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	var count int32
+	for i := range hosts.Items {
+		matches, err := r.hostMatches(ctx, hostselector, msselector, &hosts.Items[i])
+		switch {
+		case err == errConsumerNotFound:
+			log.Info("Will not scale while BareMetalHost's consuming Machine is not found", "BareMetalHost.Name", &hosts.Items[i].Name)
+			return reconcile.Result{}, nil
+		case err != nil:
+			return reconcile.Result{}, err
+		case matches == true:
+			count++
+		}
+	}
+
+	if instance.Spec.Replicas == nil || count != *instance.Spec.Replicas {
+		log.Info("Scaling MachineSet", "new_replicas", count, "old_replicas", instance.Spec.Replicas)
+		new := instance.DeepCopy()
+		new.Spec.Replicas = &count
+		err = r.Update(ctx, new)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+	}
+
+	return reconcile.Result{}, nil
+}
+
+// hostMatches returns true if the BareMetalHost matches the MachineSet.
+func (r *ReconcileMachineSet) hostMatches(ctx context.Context, hostselector labels.Selector,
+	msselector labels.Selector, host *bmh.BareMetalHost) (bool, error) {
+	consumer := host.Spec.ConsumerRef
+
+	if consumer == nil {
+		// BMH is not consumed, so just see if it matches the host selector
+		return hostselector.Matches(labels.Set(host.ObjectMeta.Labels)), nil
+	}
+
+	// We will only count this host if it is consumed by a Machine that
+	// is part of the current MachineSet.
+	machine := &machinev1beta1.Machine{}
+	if consumer.Kind != "Machine" || consumer.APIVersion != machinev1beta1.SchemeGroupVersion.String() {
+		// this host is being consumed by something else; don't count it
+		return false, nil
+	}
+
+	// host is being consumed. Let's get the Machine and see if it
+	// matches the current MachineSet.
+	nn := types.NamespacedName{
+		Name:      consumer.Name,
+		Namespace: consumer.Namespace,
+	}
+	err := r.Get(ctx, nn, machine)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return false, errConsumerNotFound
+		}
+		return false, err
+	}
+	return msselector.Matches(labels.Set(machine.ObjectMeta.Labels)), nil
+}

--- a/pkg/controller/machineset/machineset_controller_test.go
+++ b/pkg/controller/machineset/machineset_controller_test.go
@@ -1,0 +1,450 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package machineset
+
+import (
+	"encoding/json"
+	"testing"
+
+	bmoapis "github.com/metal3-io/baremetal-operator/pkg/apis"
+	bmh "github.com/metal3-io/baremetal-operator/pkg/apis/metal3/v1alpha1"
+	bmv1alpha1 "github.com/metal3-io/cluster-api-provider-baremetal/pkg/apis/baremetal/v1alpha1"
+	machinev1beta1 "github.com/openshift/cluster-api/pkg/apis/machine/v1beta1"
+	"golang.org/x/net/context"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+var expectedRequest1 = reconcile.Request{NamespacedName: types.NamespacedName{Name: "machineset1", Namespace: "default"}}
+var expectedRequest2 = reconcile.Request{NamespacedName: types.NamespacedName{Name: "machineset2", Namespace: "default"}}
+var machinesetKey1 = types.NamespacedName{Name: "machineset1", Namespace: "default"}
+var machinesetKey2 = types.NamespacedName{Name: "machineset2", Namespace: "default"}
+
+func TestHostMatches(t *testing.T) {
+	scheme := runtime.NewScheme()
+	machinev1beta1.AddToScheme(scheme)
+	ctx := context.TODO()
+
+	testCases := []struct {
+		Host          *bmh.BareMetalHost
+		HSelector     labels.Selector
+		MSSelector    labels.Selector
+		Machines      []runtime.Object
+		ExpectMatch   bool
+		ExpectMessage string
+	}{
+		{
+			Host: &bmh.BareMetalHost{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "host1",
+					Namespace: "default",
+					Labels:    map[string]string{"size": "large"},
+				},
+			},
+			HSelector: labels.SelectorFromSet(map[string]string{
+				"size": "large",
+			}),
+			MSSelector:    labels.NewSelector(),
+			ExpectMatch:   true,
+			ExpectMessage: "Expected match: available host has matching label",
+		},
+		{
+			Host: &bmh.BareMetalHost{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "host1",
+					Namespace: "default",
+					Labels:    map[string]string{"size": "large"},
+				},
+			},
+			HSelector: labels.SelectorFromSet(map[string]string{
+				"size": "extralarge",
+			}),
+			MSSelector:    labels.NewSelector(),
+			ExpectMatch:   false,
+			ExpectMessage: "Expected no match: available host has non-matching label value",
+		},
+		{
+			Host: &bmh.BareMetalHost{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "host1",
+					Namespace: "default",
+					Labels:    map[string]string{"size": "large"},
+				},
+				Spec: bmh.BareMetalHostSpec{
+					ConsumerRef: &v1.ObjectReference{
+						Kind:       "Machine",
+						APIVersion: machinev1beta1.SchemeGroupVersion.String(),
+						Name:       "machine1",
+						Namespace:  "default",
+					},
+				},
+			},
+			Machines: []runtime.Object{
+				&machinev1beta1.Machine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "machine1",
+						Namespace: "default",
+						Labels:    map[string]string{"machine.openshift.io/cluster-api-machineset": "cluster0-storage"},
+					},
+				},
+			},
+			HSelector: labels.SelectorFromSet(map[string]string{
+				"size": "extralarge",
+			}),
+			MSSelector: labels.SelectorFromSet(map[string]string{
+				"machine.openshift.io/cluster-api-machineset": "cluster0-storage",
+			}),
+			ExpectMatch:   true,
+			ExpectMessage: "Expected match: host consumer is a Machine that matches the MSSelector, even though the host has a non-matching label value",
+		},
+		{
+			Host: &bmh.BareMetalHost{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "host1",
+					Namespace: "default",
+					Labels:    map[string]string{"size": "large"},
+				},
+				Spec: bmh.BareMetalHostSpec{
+					ConsumerRef: &v1.ObjectReference{
+						Kind:       "Machine",
+						APIVersion: machinev1beta1.SchemeGroupVersion.String(),
+						Name:       "machine1",
+						Namespace:  "default",
+					},
+				},
+			},
+			Machines: []runtime.Object{
+				&machinev1beta1.Machine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "machine1",
+						Namespace: "default",
+						Labels:    map[string]string{"machine.openshift.io/cluster-api-machineset": "cluster0-workers"},
+					},
+				},
+			},
+			HSelector: labels.SelectorFromSet(map[string]string{
+				"size": "large",
+			}),
+			MSSelector: labels.SelectorFromSet(map[string]string{
+				"machine.openshift.io/cluster-api-machineset": "cluster0-storage",
+			}),
+			ExpectMatch:   false,
+			ExpectMessage: "Expected no match: host consumer is a Machine that does not match the MSSelector",
+		},
+		{
+			Host: &bmh.BareMetalHost{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "host1",
+					Namespace: "default",
+					Labels:    map[string]string{"size": "large"},
+				},
+				Spec: bmh.BareMetalHostSpec{
+					ConsumerRef: &v1.ObjectReference{
+						Kind:       "NotAMachine",
+						APIVersion: machinev1beta1.SchemeGroupVersion.String(),
+						Name:       "machine1",
+						Namespace:  "default",
+					},
+				},
+			},
+			HSelector: labels.SelectorFromSet(map[string]string{
+				"size": "large",
+			}),
+			MSSelector:    labels.NewSelector(),
+			ExpectMatch:   false,
+			ExpectMessage: "Expected no match: host consumer is not a Machine",
+		},
+		{
+			Host: &bmh.BareMetalHost{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "host1",
+					Namespace: "default",
+					Labels:    map[string]string{"size": "large"},
+				},
+				Spec: bmh.BareMetalHostSpec{
+					ConsumerRef: &v1.ObjectReference{
+						Kind:       "Machine",
+						APIVersion: "fail.metal3.io/v1alpha1",
+						Name:       "machine1",
+						Namespace:  "default",
+					},
+				},
+			},
+			HSelector: labels.SelectorFromSet(map[string]string{
+				"size": "large",
+			}),
+			MSSelector:    labels.NewSelector(),
+			ExpectMatch:   false,
+			ExpectMessage: "Expected no match: host consumer is not a Machine at the right API group/version",
+		},
+	}
+
+	for _, tc := range testCases {
+		c := fakeclient.NewFakeClientWithScheme(scheme, tc.Machines...)
+		reconciler := ReconcileMachineSet{
+			Client: c,
+			scheme: scheme,
+		}
+		result, err := reconciler.hostMatches(ctx, tc.HSelector, tc.MSSelector, tc.Host)
+		if err != nil {
+			t.Errorf("%v", err)
+		}
+		if result != tc.ExpectMatch {
+			t.Logf(tc.ExpectMessage)
+			t.FailNow()
+		}
+	}
+}
+
+func TestScale(t *testing.T) {
+	scheme := runtime.NewScheme()
+	machinev1beta1.AddToScheme(scheme)
+	bmoapis.AddToScheme(scheme)
+
+	rawProviderSpec, err := json.Marshal(&bmv1alpha1.BareMetalMachineProviderSpec{
+		HostSelector: bmv1alpha1.HostSelector{
+			MatchLabels: map[string]string{"size": "large"},
+		},
+	})
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+
+	rep := int32(17)
+	instance := &machinev1beta1.MachineSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        machinesetKey1.Name,
+			Namespace:   machinesetKey1.Namespace,
+			Annotations: map[string]string{AutoScaleAnnotation: "yesplease"},
+		},
+		Spec: machinev1beta1.MachineSetSpec{
+			Template: machinev1beta1.MachineTemplateSpec{
+				Spec: machinev1beta1.MachineSpec{
+					ProviderSpec: machinev1beta1.ProviderSpec{
+						Value: &runtime.RawExtension{Raw: rawProviderSpec},
+					},
+				},
+			},
+			Selector: metav1.LabelSelector{
+				MatchLabels: map[string]string{"machine.openshift.io/cluster-api-machineset": "cluster0-worker"},
+			},
+			Replicas: &rep,
+		},
+	}
+	// machine1 has a different label than the MachineSet's Selector, so its
+	// consumed host should not be counted as part of that MachineSet's
+	// potential hosts.
+	machine1 := machinev1beta1.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "machine1",
+			Namespace: "default",
+			Labels:    map[string]string{"machine.openshift.io/cluster-api-machineset": "cluster0-storage"},
+		},
+	}
+	// machine2 has a label that matches the MachineSet's Selector, so its
+	// consumed host should be counted as part of that MachineSet's potential
+	// hosts even if that BareMetalHost does not otherwise match.
+	machine2 := machinev1beta1.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "machine2",
+			Namespace: "default",
+			Labels:    map[string]string{"machine.openshift.io/cluster-api-machineset": "cluster0-worker"},
+		},
+	}
+	host1 := bmh.BareMetalHost{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "host1",
+			Namespace: "default",
+			Labels:    map[string]string{"size": "large"},
+		},
+	}
+	// This host has a different label, but its consuming Machine is
+	// part of the MachineSet, so it should be counted.
+	host2 := bmh.BareMetalHost{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "host2",
+			Namespace: "default",
+			Labels:    map[string]string{"size": "small"},
+		},
+		Spec: bmh.BareMetalHostSpec{
+			ConsumerRef: &v1.ObjectReference{
+				Kind:       "Machine",
+				APIVersion: machinev1beta1.SchemeGroupVersion.String(),
+				Name:       "machine2",
+				Namespace:  "default",
+			},
+		},
+	}
+	// This host has a different label, so it should not match
+	host3 := bmh.BareMetalHost{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "host3",
+			Namespace: "default",
+			Labels:    map[string]string{"size": "extramedium"},
+		},
+	}
+	// This host is consumed by a Machine in a different MachineSet, so it
+	// should not be counted
+	host4 := bmh.BareMetalHost{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "host4",
+			Namespace: "default",
+			Labels:    map[string]string{"size": "large"},
+		},
+		Spec: bmh.BareMetalHostSpec{
+			ConsumerRef: &v1.ObjectReference{
+				Kind:       "Machine",
+				APIVersion: machinev1beta1.SchemeGroupVersion.String(),
+				Name:       "machine1",
+				Namespace:  "default",
+			},
+		},
+	}
+	// This host is consumed by something that is not a Machine, so it should
+	// not be counted
+	host5 := bmh.BareMetalHost{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "host5",
+			Namespace: "default",
+			Labels:    map[string]string{"size": "large"},
+		},
+		Spec: bmh.BareMetalHostSpec{
+			ConsumerRef: &v1.ObjectReference{
+				Kind:       "NotAMachine",
+				APIVersion: machinev1beta1.SchemeGroupVersion.String(),
+				Name:       "notamachine1",
+				Namespace:  "default",
+			},
+		},
+	}
+
+	resources := []runtime.Object{
+		&host1, &host2, &host3, &host4, &host5,
+		&machine1, &machine2,
+		instance,
+	}
+	c := fakeclient.NewFakeClientWithScheme(scheme, resources...)
+	reconciler := ReconcileMachineSet{
+		Client: c,
+		scheme: scheme,
+	}
+
+	// Run reconciliation
+	_, err = reconciler.Reconcile(reconcile.Request{NamespacedName: machinesetKey1})
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+
+	// Check the MachineSet to see if it was scaled correctly
+	ms := machinev1beta1.MachineSet{}
+	err = c.Get(context.TODO(), machinesetKey1, &ms)
+	switch {
+	case err != nil:
+		t.Errorf("%v", err)
+	case ms.Spec.Replicas == nil:
+		t.Logf("Replicas is nil")
+		t.FailNow()
+	case *ms.Spec.Replicas != 2:
+		t.Logf("Replicas %d is not 2", *ms.Spec.Replicas)
+		t.FailNow()
+	}
+
+	// Delete a host and expect the MachineSet to be scaled down
+	err = c.Delete(context.TODO(), &host1)
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+
+	_, err = reconciler.Reconcile(reconcile.Request{NamespacedName: machinesetKey1})
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+
+	ms = machinev1beta1.MachineSet{}
+	err = c.Get(context.TODO(), machinesetKey1, &ms)
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+	if ms.Spec.Replicas == nil || *ms.Spec.Replicas != 1 {
+		t.Logf("Replicas is not 1")
+		t.FailNow()
+	}
+}
+
+// TestIgnore ensures that a MachineSet without the annotation gets ignored.
+func TestIgnore(t *testing.T) {
+	scheme := runtime.NewScheme()
+	machinev1beta1.AddToScheme(scheme)
+	bmoapis.AddToScheme(scheme)
+
+	rawProviderSpec, err := json.Marshal(&bmv1alpha1.BareMetalMachineProviderSpec{})
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+
+	// Since there are no BareMetalHosts, this would be scaled to 0 if it had
+	// the annotation. Since it does not have the annotation, it should be
+	// ignored.
+	five := int32(5)
+	instance := &machinev1beta1.MachineSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      machinesetKey2.Name,
+			Namespace: machinesetKey2.Namespace,
+		},
+		Spec: machinev1beta1.MachineSetSpec{
+			Replicas: &five,
+			Template: machinev1beta1.MachineTemplateSpec{
+				Spec: machinev1beta1.MachineSpec{
+					ProviderSpec: machinev1beta1.ProviderSpec{
+						Value: &runtime.RawExtension{Raw: rawProviderSpec},
+					},
+				},
+			},
+			Selector: metav1.LabelSelector{
+				MatchLabels: map[string]string{"machine.openshift.io/cluster-api-machineset": "cluster0-worker"},
+			},
+		},
+	}
+
+	c := fakeclient.NewFakeClientWithScheme(scheme, instance)
+	reconciler := ReconcileMachineSet{
+		Client: c,
+		scheme: scheme,
+	}
+
+	// Run reconciliation
+	_, err = reconciler.Reconcile(reconcile.Request{NamespacedName: machinesetKey2})
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+
+	// Verify that the MachineSet did not get scaled.
+	ms := machinev1beta1.MachineSet{}
+	err = c.Get(context.TODO(), machinesetKey2, &ms)
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+	if *ms.Spec.Replicas != 5 {
+		t.Logf("replicas is not 5; the MachineSet was not ignored as expected")
+		t.FailNow()
+	}
+}

--- a/pkg/controller/machineset/mapper.go
+++ b/pkg/controller/machineset/mapper.go
@@ -1,0 +1,72 @@
+package machineset
+
+import (
+	"context"
+	"fmt"
+
+	bmh "github.com/metal3-io/baremetal-operator/pkg/apis/metal3/v1alpha1"
+	actuator "github.com/metal3-io/cluster-api-provider-baremetal/pkg/cloud/baremetal/actuators/machine"
+	machinev1beta1 "github.com/openshift/cluster-api/pkg/apis/machine/v1beta1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// AutoScaleAnnotation is an annotation key that, when added to a MachineSet
+// with any value, indicates that this controller should scale that MachineSet
+// to equal the number of matching BareMetalHosts in the same namespace.
+const AutoScaleAnnotation = "metal3.io/autoscale-to-hosts"
+
+type msmapper struct {
+	client client.Client
+}
+
+// Map will return reconcile requests for a MachineSet if the event is for a
+// BareMetalHost and that BareMetalHost matches the MachineSet's HostSelector.
+func (m *msmapper) Map(obj handler.MapObject) []reconcile.Request {
+	requests := []reconcile.Request{}
+	if host, ok := obj.Object.(*bmh.BareMetalHost); ok {
+		msets := machinev1beta1.MachineSetList{}
+		err := m.client.List(context.TODO(), &msets, client.UseListOptions(&client.ListOptions{Namespace: host.Namespace}))
+		if err != nil {
+			log.Error(err, "failed to list MachineSets")
+			return []reconcile.Request{}
+		}
+		for _, ms := range msets.Items {
+			annotations := ms.ObjectMeta.GetAnnotations()
+			if annotations == nil {
+				continue
+			}
+			_, present := annotations[AutoScaleAnnotation]
+			if !present {
+				continue
+			}
+
+			matches, err := m.hostMatchesMachineSet(host, &ms)
+			if err != nil {
+				nn := fmt.Sprintf("%s/%s", ms.Namespace, ms.Name)
+				log.Error(err, "failed to determine if host matches MachineSet", "MachineSet", nn)
+				continue
+			}
+			if matches {
+				requests = append(requests, reconcile.Request{
+					NamespacedName: types.NamespacedName{
+						Name:      ms.Name,
+						Namespace: ms.Namespace,
+					},
+				})
+			}
+		}
+	}
+	return requests
+}
+
+func (m *msmapper) hostMatchesMachineSet(host *bmh.BareMetalHost, ms *machinev1beta1.MachineSet) (bool, error) {
+	selector, err := actuator.SelectorFromProviderSpec(&ms.Spec.Template.Spec.ProviderSpec)
+	if err != nil {
+		return false, err
+	}
+	return selector.Matches(labels.Set(host.ObjectMeta.Labels)), nil
+}

--- a/pkg/controller/machineset/mapper_test.go
+++ b/pkg/controller/machineset/mapper_test.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package machineset
+
+import (
+	"encoding/json"
+	"testing"
+
+	bmoapis "github.com/metal3-io/baremetal-operator/pkg/apis"
+	bmh "github.com/metal3-io/baremetal-operator/pkg/apis/metal3/v1alpha1"
+	bmv1alpha1 "github.com/metal3-io/cluster-api-provider-baremetal/pkg/apis/baremetal/v1alpha1"
+	machinev1beta1 "github.com/openshift/cluster-api/pkg/apis/machine/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+)
+
+func TestMapper(t *testing.T) {
+	scheme := runtime.NewScheme()
+	machinev1beta1.AddToScheme(scheme)
+	bmoapis.AddToScheme(scheme)
+
+	testCases := []struct {
+		Host          *bmh.BareMetalHost
+		Annotations   map[string]string
+		ExpectRequest bool
+		FailMessage   string
+	}{
+		{
+			Host: &bmh.BareMetalHost{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "host1",
+					Namespace: "default",
+					Labels:    map[string]string{"size": "large"},
+				},
+			},
+			Annotations:   map[string]string{AutoScaleAnnotation: "yesplease"},
+			ExpectRequest: true,
+			FailMessage:   "host with annotation and matching label should generate a request",
+		},
+		{
+			Host: &bmh.BareMetalHost{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "host1",
+					Namespace: "default",
+					Labels:    map[string]string{"size": "medium"},
+				},
+			},
+			Annotations:   map[string]string{AutoScaleAnnotation: "yesplease"},
+			ExpectRequest: false,
+			FailMessage:   "host with annotation and non-matching label should not generate a request",
+		},
+		{
+			Host: &bmh.BareMetalHost{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "host1",
+					Namespace: "default",
+					Labels:    map[string]string{"size": "large"},
+				},
+			},
+			Annotations:   map[string]string{},
+			ExpectRequest: false,
+			FailMessage:   "host without annotation should not generate a request",
+		},
+	}
+
+	for _, tc := range testCases {
+		ms, err := newMachineSet(tc.Annotations)
+		if err != nil {
+			t.Errorf("%v", err)
+		}
+		c := fakeclient.NewFakeClientWithScheme(scheme, ms, tc.Host)
+		mapper := msmapper{client: c}
+
+		mo := handler.MapObject{
+			Object: tc.Host,
+			Meta:   &tc.Host.ObjectMeta,
+		}
+		requests := mapper.Map(mo)
+
+		if tc.ExpectRequest {
+			if len(requests) != 1 {
+				t.Logf("expected 1 request, got %d", len(requests))
+				t.Logf(tc.FailMessage)
+				t.FailNow()
+			}
+			req := requests[0]
+			if req.NamespacedName.Name != ms.Name {
+				t.Logf("expected Name %s, got %s", req.NamespacedName.Name, ms.Name)
+				t.Logf(tc.FailMessage)
+				t.FailNow()
+			}
+			if req.NamespacedName.Namespace != ms.Namespace {
+				t.Logf("expected NameSpace %s, got %s", req.NamespacedName.Namespace, ms.Namespace)
+				t.Logf(tc.FailMessage)
+				t.FailNow()
+			}
+		} else if len(requests) != 0 {
+			t.Logf("expected 0 requests, got %d", len(requests))
+			t.Logf(tc.FailMessage)
+			t.FailNow()
+		}
+	}
+}
+
+func newMachineSet(annotations map[string]string) (*machinev1beta1.MachineSet, error) {
+	rawProviderSpec, err := json.Marshal(&bmv1alpha1.BareMetalMachineProviderSpec{
+		HostSelector: bmv1alpha1.HostSelector{
+			MatchLabels: map[string]string{"size": "large"},
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	two := int32(2)
+	return &machinev1beta1.MachineSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        machinesetKey1.Name,
+			Namespace:   machinesetKey1.Namespace,
+			Annotations: annotations,
+		},
+		Spec: machinev1beta1.MachineSetSpec{
+			Template: machinev1beta1.MachineTemplateSpec{
+				Spec: machinev1beta1.MachineSpec{
+					ProviderSpec: machinev1beta1.ProviderSpec{
+						Value: &runtime.RawExtension{Raw: rawProviderSpec},
+					},
+				},
+			},
+			Selector: metav1.LabelSelector{
+				MatchLabels: map[string]string{"machine.openshift.io/cluster-api-machineset": "cluster0-worker"},
+			},
+			Replicas: &two,
+		},
+	}, nil
+}


### PR DESCRIPTION
In many clusters, it is desirable for the size of a MachineSet to always equal
the number of matching BareMetalHosts. In such a scenario, the cluster owner
wants all of their hardware to be provisioned and turned into Nodes, and they
want to remove excess Machines in case they remove hosts from their cluster.
This change adds a controller that scales MachineSets to the number of matching
BareMetalHosts. The behavior is opt-in, requiring an annotation on the
MachineSet.