### PR TITLE
Enable leader election

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -43,6 +43,7 @@ func main() {
 
 	watchNamespace := flag.String("namespace", "", "Namespace that the controller watches to reconcile machine-api objects. If unspecified, the controller watches for machine-api objects across all namespaces.")
 	metricsAddr := flag.String("metrics-addr", ":8080", "The address the metric endpoint binds to.")
+	enableLeaderElection := flag.Bool("enable-leader-election", false, "Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 	flag.Parse()
 
 	log := logf.Log.WithName("baremetal-controller-manager")
@@ -63,6 +64,8 @@ func main() {
 	// Setup a Manager
 	opts := manager.Options{
 		MetricsBindAddress: *metricsAddr,
+		LeaderElection:     *enableLeaderElection,
+		LeaderElectionID:   "controller-leader-election-capbm",
 	}
 	if *watchNamespace != "" {
 		opts.Namespace = *watchNamespace

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -22,3 +22,4 @@ spec:
       - name: manager
         args:
         - "--metrics-addr=127.0.0.1:8080"
+        - "--enable-leader-election"


### PR DESCRIPTION
Add a command-line flag to allow leader election to be enabled when
running in a cluster. This is consistent with how leader election is now
done upstream.