### PR TITLE
Restore node's annotations and labels after remediation

### DIFF
--- a/pkg/cloud/baremetal/actuators/machine/actuator.go
+++ b/pkg/cloud/baremetal/actuators/machine/actuator.go
@@ -501,7 +501,7 @@ func (a *Actuator) ensureAnnotation(ctx context.Context, machine *machinev1beta1
 // handleNodeFinalizer adds finalizer to Node if not already exists
 // it also store the node annotations and labels on Machine annotations
 // upon node deletion
-func (a *Actuator) handleNodeFinalizer(ctx context.Context, machine *machinev1.Machine) error {
+func (a *Actuator) handleNodeFinalizer(ctx context.Context, machine *machinev1beta1.Machine) error {
 	node, err := a.getNodeByMachine(ctx, machine)
 	if err != nil {
 		if errors.IsNotFound(err) {
@@ -841,7 +841,7 @@ func (a *Actuator) remediateIfNeeded(ctx context.Context, machine *machinev1beta
 }
 
 // storeAnnotationsAndLabels copies node's annotations and labels and stores them on machine's annotations
-func (a *Actuator) storeAnnotationsAndLabels(ctx context.Context, node *corev1.Node, machine *machinev1.Machine) error {
+func (a *Actuator) storeAnnotationsAndLabels(ctx context.Context, node *corev1.Node, machine *machinev1beta1.Machine) error {
 	marshaledAnnotations, err := marshal(node.Annotations)
 	if err != nil {
 		log.Printf("Failed to marshal node %s annotations associated with Machine %s: %s",
@@ -871,9 +871,9 @@ func (a *Actuator) storeAnnotationsAndLabels(ctx context.Context, node *corev1.N
 
 // restoreAnnotationsAndLabels copies annotations and labels stored in machine's annotation to the node
 // and removes the annotations used to store that data
-func (a *Actuator) restoreAnnotationsAndLabels(ctx context.Context, node *corev1.Node, machine *machinev1.Machine) error {
+func (a *Actuator) restoreAnnotationsAndLabels(ctx context.Context, node *corev1.Node, machine *machinev1beta1.Machine) error {
 	if len(machine.Annotations) == 0 {
-		return &clustererror.RequeueAfterError{}
+		return &machineapierrors.RequeueAfterError{}
 	}
 
 	nodeAnn, err := unmarshal(machine.Annotations[nodeAnnotationsBackupAnnotation])

--- a/pkg/cloud/baremetal/actuators/machine/actuator.go
+++ b/pkg/cloud/baremetal/actuators/machine/actuator.go
@@ -18,12 +18,8 @@ package machine
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
-	"log"
-	"math/rand"
-	"strings"
-	"time"
-
 	bmh "github.com/metal3-io/baremetal-operator/pkg/apis/metal3/v1alpha1"
 	"github.com/metal3-io/baremetal-operator/pkg/utils"
 	bmv1alpha1 "github.com/openshift/cluster-api-provider-baremetal/pkg/apis/baremetal/v1alpha1"
@@ -36,8 +32,12 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/client-go/tools/cache"
+	"log"
+	"math/rand"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
+	"strings"
+	"time"
 )
 
 const (

--- a/pkg/cloud/baremetal/actuators/machine/actuator.go
+++ b/pkg/cloud/baremetal/actuators/machine/actuator.go
@@ -524,7 +524,7 @@ func (a *Actuator) handleNodeFinalizer(ctx context.Context, machine *machinev1.M
 	} else {
 		//node is in deletion process
 		if utils.StringInList(node.Finalizers, nodeFinalizer) {
-			if err := a.storeAnnotationsAndLabels(node, machine, ctx); err != nil {
+			if err := a.storeAnnotationsAndLabels(ctx, node, machine); err != nil {
 				return err
 			}
 
@@ -833,7 +833,7 @@ func (a *Actuator) remediateIfNeeded(ctx context.Context, machine *machinev1beta
 
 	// node is now available again - restore annotations and labels
 	if _, annotationsBackupExists := machine.Annotations[nodeAnnotationsBackupAnnotation]; annotationsBackupExists {
-		return a.restoreAnnotationsAndLabels(node, machine, ctx)
+		return a.restoreAnnotationsAndLabels(ctx, node, machine)
 	}
 
 	//remediation is done
@@ -842,7 +842,7 @@ func (a *Actuator) remediateIfNeeded(ctx context.Context, machine *machinev1beta
 }
 
 // storeAnnotationsAndLabels copies node's annotations and labels and stores them on machine's annotations
-func (a *Actuator) storeAnnotationsAndLabels(node *corev1.Node, machine *machinev1.Machine, ctx context.Context) error {
+func (a *Actuator) storeAnnotationsAndLabels(ctx context.Context, node *corev1.Node, machine *machinev1.Machine) error {
 	marshaledAnnotations, err := marshal(node.Annotations)
 	if err != nil {
 		log.Printf("Failes to marshal node %s annotations assoicated with Machine %s: %s",
@@ -871,7 +871,7 @@ func (a *Actuator) storeAnnotationsAndLabels(node *corev1.Node, machine *machine
 
 // restoreAnnotationsAndLabels copies annotations and labels stored in machine's annotation to the node
 // and removes the annotations used to store that data
-func (a *Actuator) restoreAnnotationsAndLabels(node *corev1.Node, machine *machinev1.Machine, ctx context.Context) error {
+func (a *Actuator) restoreAnnotationsAndLabels(ctx context.Context, node *corev1.Node, machine *machinev1.Machine) error {
 	if len(machine.Annotations) == 0 {
 		return &clustererror.RequeueAfterError{}
 	}

--- a/pkg/cloud/baremetal/actuators/machine/actuator.go
+++ b/pkg/cloud/baremetal/actuators/machine/actuator.go
@@ -909,7 +909,7 @@ func (a *Actuator) restoreAnnotationsAndLabels(ctx context.Context, node *corev1
 }
 
 // mergeMaps takes entries from mapToMerge and adds them to prioritizedMap, if entry key not already
-// exists in prioritizedMap. It returns the merged mapsssss
+// exists in prioritizedMap. It returns the merged maps
 func (a *Actuator) mergeMaps(prioritizedMap map[string]string, mapToMerge map[string]string) map[string]string {
 	if prioritizedMap == nil {
 		prioritizedMap = make(map[string]string)

--- a/pkg/cloud/baremetal/actuators/machine/actuator.go
+++ b/pkg/cloud/baremetal/actuators/machine/actuator.go
@@ -766,12 +766,11 @@ remediateIfNeeded will try to remediate unhealthy machines (annotated by MHC) by
 The full remediation flow is:
 1) Power off the host
 2) Add poweredOffForRemediation annotation to the unhealthy Machine
-3) Store node's annotations and labels in Machine's annotations
-4) Delete the node
-5) Power on the host
-6) Wait for the node the come up (by waiting for the node to be registered in the cluster)
-7) Restore node's annotations and labels
-8) Remove poweredOffForRemediation annotation, MAO's machine unhealthy annotation and annotations/labels backup
+3) Delete the node
+4) Power on the host
+5) Wait for the node the come up (by waiting for the node to be registered in the cluster)
+6) Restore node's annotations and labels
+7) Remove poweredOffForRemediation annotation, MAO's machine unhealthy annotation and annotations/labels backup
 */
 func (a *Actuator) remediateIfNeeded(ctx context.Context, machine *machinev1beta1.Machine, baremetalhost *bmh.BareMetalHost) error {
 	if len(machine.Annotations) == 0 {

--- a/pkg/cloud/baremetal/actuators/machine/actuator.go
+++ b/pkg/cloud/baremetal/actuators/machine/actuator.go
@@ -847,14 +847,14 @@ func (a *Actuator) storeAnnotationsAndLabels(ctx context.Context, node *corev1.N
 	if err != nil {
 		log.Printf("Failed to marshal node %s annotations associated with Machine %s: %s",
 			node.Name, machine.Name, err.Error())
-		return err
+		return nil
 	}
 
 	marshaledLabels, err := marshal(node.Labels)
 	if err != nil {
 		log.Printf("Failed to marshal node %s labels associated with Machine %s: %s",
 			node.Name, machine.Name, err.Error())
-		return err
+		return nil
 	}
 
 	machine.Annotations[nodeLabelsBackupAnnotation] = marshaledLabels
@@ -879,13 +879,13 @@ func (a *Actuator) restoreAnnotationsAndLabels(ctx context.Context, node *corev1
 	nodeAnn, err := unmarshal(machine.Annotations[nodeAnnotationsBackupAnnotation])
 	if err != nil {
 		log.Printf("failed to unmarshal node's annotations from %s: %s", machine.Name, err.Error())
-		return err
+		return nil
 	}
 
 	nodeLabels, err := unmarshal(machine.Annotations[nodeLabelsBackupAnnotation])
 	if err != nil {
 		log.Printf("failed to unmarshal node's labels from %s: %s", machine.Name, err.Error())
-		return err
+		return nil
 	}
 
 	node.Annotations = a.mergeMaps(node.Annotations, nodeAnn)
@@ -910,7 +910,7 @@ func (a *Actuator) restoreAnnotationsAndLabels(ctx context.Context, node *corev1
 }
 
 // mergeMaps takes entries from mapToMerge and adds them to prioritizedMap, if entry key not already
-// exists in prioritizedMap. It returns the merged map
+// exists in prioritizedMap. It returns the merged mapsssss
 func (a *Actuator) mergeMaps(prioritizedMap map[string]string, mapToMerge map[string]string) map[string]string {
 	if prioritizedMap == nil {
 		prioritizedMap = make(map[string]string)

--- a/pkg/cloud/baremetal/actuators/machine/actuator.go
+++ b/pkg/cloud/baremetal/actuators/machine/actuator.go
@@ -930,17 +930,17 @@ func (a *Actuator) mergeMaps(prioritizedMap map[string]string, mapToMerge map[st
 }
 
 // marshal is a wrapper for json.marshal() and converts its output to string
-// if m is nil or empty an empty string will be returned
+// if m is nil - an empty string will be returned
 func marshal(m map[string]string) (string, error) {
-	var err error
-	var marshaled []byte
-
-	if len(m) > 0 {
-		marshaled, err = json.Marshal(m)
-		if err != nil {
-			return "", err
-		}
+	if m == nil {
+		return "", nil
 	}
+
+	marshaled, err := json.Marshal(m)
+	if err != nil {
+		return "", err
+	}
+
 	return string(marshaled), nil
 }
 

--- a/pkg/cloud/baremetal/actuators/machine/actuator.go
+++ b/pkg/cloud/baremetal/actuators/machine/actuator.go
@@ -882,6 +882,10 @@ func marshal(m map[string]string) (string, error) {
 
 // unmarshal is a wrapper for json.Unmarshal() for marshaled strings that represent map[string]string
 func unmarshal(marshaled string) (map[string]string, error) {
+	if marshaled == "" {
+		return make(map[string]string), nil
+	}
+
 	decodedValue := make(map[string]string)
 
 	if err := json.Unmarshal([]byte(marshaled), &decodedValue); err != nil {

--- a/pkg/cloud/baremetal/actuators/machine/actuator.go
+++ b/pkg/cloud/baremetal/actuators/machine/actuator.go
@@ -905,7 +905,7 @@ func (a *Actuator) restoreAnnotationsAndLabels(ctx context.Context, node *corev1
 		return err
 	}
 
-	return &clustererror.RequeueAfterError{}
+	return nil
 }
 
 // mergeMaps takes entries from mapToMerge and adds them to prioritizedMap, if entry key not already

--- a/pkg/cloud/baremetal/actuators/machine/actuator.go
+++ b/pkg/cloud/baremetal/actuators/machine/actuator.go
@@ -49,8 +49,8 @@ const (
 	externalRemediationAnnotation   = "host.metal3.io/external-remediation"
 	poweredOffForRemediation        = "remediation.metal3.io/powered-off-for-remediation"
 	requestPowerOffAnnotation       = "reboot.metal3.io/capbm-requested-power-off"
-	nodeLabelsBackupAnnotation      = "remediation.metal3.io/nodeLabelsBackup"
-	nodeAnnotationsBackupAnnotation = "remediation.metal3.io/nodeAnnotationsBackup"
+	nodeLabelsBackupAnnotation      = "remediation.metal3.io/node-labels-backup"
+	nodeAnnotationsBackupAnnotation = "remediation.metal3.io/node-annotations-backup"
 	nodeFinalizer                   = "machine.openshift.io"
 )
 

--- a/pkg/cloud/baremetal/actuators/machine/actuator.go
+++ b/pkg/cloud/baremetal/actuators/machine/actuator.go
@@ -845,14 +845,14 @@ func (a *Actuator) remediateIfNeeded(ctx context.Context, machine *machinev1beta
 func (a *Actuator) storeAnnotationsAndLabels(ctx context.Context, node *corev1.Node, machine *machinev1.Machine) error {
 	marshaledAnnotations, err := marshal(node.Annotations)
 	if err != nil {
-		log.Printf("Failes to marshal node %s annotations assoicated with Machine %s: %s",
+		log.Printf("Failed to marshal node %s annotations associated with Machine %s: %s",
 			node.Name, machine.Name, err.Error())
 		return err
 	}
 
 	marshaledLabels, err := marshal(node.Labels)
 	if err != nil {
-		log.Printf("Failes to marshal node %s labels assoicated with Machine %s: %s",
+		log.Printf("Failed to marshal node %s labels associated with Machine %s: %s",
 			node.Name, machine.Name, err.Error())
 		return err
 	}
@@ -862,7 +862,7 @@ func (a *Actuator) storeAnnotationsAndLabels(ctx context.Context, node *corev1.N
 
 	err = a.client.Update(ctx, machine)
 	if err != nil {
-		log.Printf("failed to update machine with node's annotations and labels %s: %s", machine.Name, err.Error())
+		log.Printf("Failed to update machine with node's annotations and labels %s: %s", machine.Name, err.Error())
 		return err
 	}
 

--- a/pkg/cloud/baremetal/actuators/machine/actuator.go
+++ b/pkg/cloud/baremetal/actuators/machine/actuator.go
@@ -51,7 +51,7 @@ const (
 	requestPowerOffAnnotation       = "reboot.metal3.io/capbm-requested-power-off"
 	nodeLabelsBackupAnnotation      = "remediation.metal3.io/node-labels-backup"
 	nodeAnnotationsBackupAnnotation = "remediation.metal3.io/node-annotations-backup"
-	nodeFinalizer                   = "machine.openshift.io"
+	nodeFinalizer                   = "capbm.metal3.io"
 )
 
 // Add RBAC rules to access cluster-api resources

--- a/pkg/cloud/baremetal/actuators/machine/actuator_test.go
+++ b/pkg/cloud/baremetal/actuators/machine/actuator_test.go
@@ -6,9 +6,6 @@ import (
 	"testing"
 	"time"
 	"reflect"
-	"encoding/base64"
-	"encoding/pem"
-	"fmt"
 	bmoapis "github.com/metal3-io/baremetal-operator/pkg/apis"
 	bmh "github.com/metal3-io/baremetal-operator/pkg/apis/metal3/v1alpha1"
 	bmv1alpha1 "github.com/openshift/cluster-api-provider-baremetal/pkg/apis/baremetal/v1alpha1"
@@ -21,8 +18,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"net/http"
-	"net/http/httptest"
 )
 
 const (

--- a/pkg/cloud/baremetal/actuators/machine/actuator_test.go
+++ b/pkg/cloud/baremetal/actuators/machine/actuator_test.go
@@ -1660,6 +1660,10 @@ func TestMarshalAndUnmarshal(t *testing.T) {
 		t.Errorf("marshal() returned an err: %s", err.Error())
 	}
 
+	if marshaled != "" {
+		t.Errorf("Expected marshal(nil) to return an empty string, but recieved: %s ", marshaled)
+	}
+
 	unmarshaled, err = unmarshal(marshaled)
 
 	if err != nil {
@@ -1676,6 +1680,10 @@ func TestMarshalAndUnmarshal(t *testing.T) {
 
 	if err != nil {
 		t.Errorf("marshal() returned an err: %s", err.Error())
+	}
+
+	if marshaled != "{}" {
+		t.Errorf("Expected marshal() with empty map to return {} but got %s", marshaled)
 	}
 
 	unmarshaled, err = unmarshal(marshaled)

--- a/pkg/cloud/baremetal/actuators/machine/actuator_test.go
+++ b/pkg/cloud/baremetal/actuators/machine/actuator_test.go
@@ -1830,16 +1830,10 @@ func TestRemediation(t *testing.T) {
 
 	machine = &machinev1beta1.Machine{}
 	c.Get(context.TODO(), machineNamespacedName, machine)
+
 	err = actuator.Update(context.TODO(), machine)
-	if err == nil {
-		t.Errorf("expected a requeue err but err was nil")
-	} else {
-		switch err.(type) {
-		case *machineapierrors.RequeueAfterError:
-			break
-		default:
-			t.Errorf("unexpected error %v", err)
-		}
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
 	}
 
 	node = &corev1.Node{}

--- a/pkg/cloud/baremetal/actuators/machine/actuator_test.go
+++ b/pkg/cloud/baremetal/actuators/machine/actuator_test.go
@@ -1632,6 +1632,63 @@ func TestDeleteOfBareMetalHostDeletesMachine(t *testing.T) {
 	}
 }
 
+func TestMarshalAndUnmarshal(t *testing.T) {
+	m := map[string]string{"key1":"val1","keyWithEmptyValue":"","key.with.dots":"value.with.dots"}
+
+	marshaled, err := marshal(m)
+
+	if err != nil {
+		t.Errorf("marshal() returned an err: %s", err.Error())
+	}
+
+	unmarshaled, err := unmarshal(marshaled)
+
+	if err != nil {
+		t.Errorf("unmarshal returned an err: %s", err.Error())
+	}
+
+	if !reflect.DeepEqual(unmarshaled, m) {
+		t.Errorf("map is different after unmarshal(marshal(map)). Original map was: %s , unmarshaled map: %s",
+					m, unmarshaled)
+	}
+
+	m = nil
+
+	marshaled, err = marshal(m)
+
+	if err != nil {
+		t.Errorf("marshal() returned an err: %s", err.Error())
+	}
+
+	unmarshaled, err = unmarshal(marshaled)
+
+	if err != nil {
+		t.Errorf("unmarshal returned an err: %s", err.Error())
+	}
+
+	if len(unmarshaled) != 0 {
+		t.Errorf("Expected unmarshal(marshal(nil)) to return an empty map but recieved: %s", unmarshaled)
+	}
+
+	m = make(map[string]string)
+
+	marshaled, err = marshal(m)
+
+	if err != nil {
+		t.Errorf("marshal() returned an err: %s", err.Error())
+	}
+
+	unmarshaled, err = unmarshal(marshaled)
+
+	if err != nil {
+		t.Errorf("unmarshal returned an err: %s", err.Error())
+	}
+
+	if len(unmarshaled) != 0 {
+		t.Errorf("Expected unmarshal(marshal([])) to return an empty map but recieved: %s", unmarshaled)
+	}
+}
+
 func TestRemediation(t *testing.T) {
 	machine, machineNamespacedName := getMachine("machine1")
 	host, hostNamespacedName := getBareMetalHost("host1")

--- a/pkg/manager/wrapper/bmh_mapper.go
+++ b/pkg/manager/wrapper/bmh_mapper.go
@@ -8,11 +8,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-type mapper struct{}
+type bmhMapper struct{}
 
 // Map will return a reconcile request for a Machine if the event is for a
 // BareMetalHost and that BareMetalHost references a Machine.
-func (m *mapper) Map(obj handler.MapObject) []reconcile.Request {
+func (m *bmhMapper) Map(obj handler.MapObject) []reconcile.Request {
 	if host, ok := obj.Object.(*bmh.BareMetalHost); ok {
 		if host.Spec.ConsumerRef != nil && host.Spec.ConsumerRef.Kind == "Machine" && host.Spec.ConsumerRef.APIVersion == machinev1beta1.SchemeGroupVersion.String() {
 			return []reconcile.Request{

--- a/pkg/manager/wrapper/bmh_mapper_test.go
+++ b/pkg/manager/wrapper/bmh_mapper_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestMap(t *testing.T) {
-	m := mapper{}
+	m := bmhMapper{}
 
 	for _, tc := range []struct {
 		Host          *bmh.BareMetalHost

--- a/pkg/manager/wrapper/node_mapper.go
+++ b/pkg/manager/wrapper/node_mapper.go
@@ -13,7 +13,7 @@ type nodeMapper struct{}
 const MachineAnnotation = "machine.openshift.io/machine"
 
 // Map will return a reconcile request for a Machine if the event is for a
-// BareMetalHost and that BareMetalHost references a Machine.
+// Node and that Node references a Machine.
 func (m *nodeMapper) Map(obj handler.MapObject) []reconcile.Request {
 	if node, ok := obj.Object.(*corev1.Node); ok {
 		machineKey, ok := node.Annotations[MachineAnnotation]

--- a/pkg/manager/wrapper/node_mapper.go
+++ b/pkg/manager/wrapper/node_mapper.go
@@ -1,0 +1,39 @@
+package wrapper
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/cache"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+type nodeMapper struct{}
+
+const MachineAnnotation = "machine.openshift.io/machine"
+
+// Map will return a reconcile request for a Machine if the event is for a
+// BareMetalHost and that BareMetalHost references a Machine.
+func (m *nodeMapper) Map(obj handler.MapObject) []reconcile.Request {
+	if node, ok := obj.Object.(*corev1.Node); ok {
+		machineKey, ok := node.Annotations[MachineAnnotation]
+		if !ok {
+			return []reconcile.Request{}
+		}
+
+		namespace, machineName, err := cache.SplitMetaNamespaceKey(machineKey)
+		if err != nil {
+			return []reconcile.Request{}
+		}
+
+		return []reconcile.Request{
+			reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: namespace,
+					Name:      machineName,
+				},
+			},
+		}
+	}
+	return []reconcile.Request{}
+}

--- a/pkg/manager/wrapper/node_mapper.go
+++ b/pkg/manager/wrapper/node_mapper.go
@@ -4,6 +4,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
+	"log"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -23,6 +24,7 @@ func (m *nodeMapper) Map(obj handler.MapObject) []reconcile.Request {
 
 		namespace, machineName, err := cache.SplitMetaNamespaceKey(machineKey)
 		if err != nil {
+			log.Printf("Error mapping Node %s to Machine: %s", node.Name, err.Error())
 			return []reconcile.Request{}
 		}
 

--- a/pkg/manager/wrapper/wrapper.go
+++ b/pkg/manager/wrapper/wrapper.go
@@ -5,6 +5,7 @@ import (
 	"log"
 
 	bmh "github.com/metal3-io/baremetal-operator/pkg/apis/metal3/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
@@ -51,11 +52,18 @@ func (m *managerWrapper) Add(r manager.Runnable) error {
 		return fmt.Errorf("Controller was nil")
 	}
 
-	err = c.Watch(&source.Kind{Type: &bmh.BareMetalHost{}}, &handler.EnqueueRequestsFromMapFunc{ToRequests: &mapper{}})
+	err = c.Watch(&source.Kind{Type: &bmh.BareMetalHost{}}, &handler.EnqueueRequestsFromMapFunc{ToRequests: &bmhMapper{}})
 	if err != nil {
 		log.Printf("Error watching BareMetalHosts: %s", err.Error())
 		return err
 	}
+
+	err = c.Watch(&source.Kind{Type: &corev1.Node{}}, &handler.EnqueueRequestsFromMapFunc{ToRequests: &nodeMapper{}})
+	if err != nil {
+		log.Printf("Error watching Nodes: %s", err.Error())
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
The current Machine Remediation code is deleting the node object, together with its annotations and labels.
This is problematic because the labels and annotations may be used to organize nodes and assign workloads.

This PR store the annotations and labels on the machine, and restore them when the node re-registers.

Signed-off-by: Nir <niry@redhat.com>