### PR TITLE
Fix metrics

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -55,9 +55,10 @@ func main() {
 		"The address for health checking.",
 	)
 
+	// Default machine metrics address defined by MAO - https://github.com/openshift/machine-api-operator/blob/master/pkg/metrics/metrics.go#L16
 	metricsAddr := flag.String(
 		"metrics-addr",
-		":8080",
+		":8081",
 		"The address the metric endpoint binds to.",
 	)
 

--- a/config/default/manager_prometheus_metrics_patch.yaml
+++ b/config/default/manager_prometheus_metrics_patch.yaml
@@ -14,6 +14,6 @@ spec:
       # Expose the prometheus metrics on default port
       - name: manager
         ports:
-        - containerPort: 8080
+        - containerPort: 8081
           name: metrics
           protocol: TCP


### PR DESCRIPTION
This change ensures compatibility with the `ServiceMonitor` resource
introduced in openshift/machine-api-operator#609

Close #75 