### PR TITLE
Change node finalizer name to match api requirements

### DIFF
--- a/pkg/cloud/baremetal/actuators/machine/actuator.go
+++ b/pkg/cloud/baremetal/actuators/machine/actuator.go
@@ -51,7 +51,7 @@ const (
 	requestPowerOffAnnotation       = "reboot.metal3.io/capbm-requested-power-off"
 	nodeLabelsBackupAnnotation      = "remediation.metal3.io/node-labels-backup"
 	nodeAnnotationsBackupAnnotation = "remediation.metal3.io/node-annotations-backup"
-	nodeFinalizer                   = "capbm.metal3.io"
+	nodeFinalizer                   = "metal3.io/capbm"
 )
 
 // Add RBAC rules to access cluster-api resources


### PR DESCRIPTION
It seems that k8s doesn't accept finalizer name if it doesn't contain /
See this for more details:
https://github.com/kubernetes/kubernetes/blob/205d5c58296357365bfa834ecabb384c1c1042c3/pkg/apis/core/validation/validation.go#L5515

Also, I got an error after adding trailing / without any value

Fixing https://bugzilla.redhat.com/show_bug.cgi?id=1855049
The error message:
```
020/07/08 18:12:51 Failed to add node finalizer to node worker-0-0, error: Node "worker-0-0" is invalid: metadata.finalizers[0]: Invalid value: "capbm.metal3.io": name is neither a standard finalizer name nor is it fully qualified     
E0708 18:12:51.059738       1 controller.go:275] ocp-edge-cluster-rdu2-0-worker-0-p722p: error updating machine: Node "worker-0-0" is invalid: metadata.finalizers[0]: Invalid value: "capbm.metal3.io": name is neither a standard finalizer name nor is it fully qualified
{"level":"error","ts":1594231971.0597603,"logger":"controller-runtime.controller","msg":"Reconciler error","controller":"machine_controller","request":"openshift-machine-api/ocp-edge-cluster-rdu2-0-worker-0-p722p","error":"Node \"worker-0-0\" is invalid: metadata.finalizers[0]: Invalid value: \"capbm.metal3.io\": name is neither a standard finalizer name nor is it fully qualified","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/go/src/github.com/openshift/cluster-api-provider-baremetal/vendor/github.com/go-logr/zapr/zapr.go:128\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/go/src/github.com/openshift/cluster-api-provider-baremetal/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:258\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/go/src/github.com/openshift/cluster-api-provider-baremetal/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:232\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker\n\t/go/src/github.com/openshift/cluster-api-provider-baremetal/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:211\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1\n\t/go/src/github.com/openshift/cluster-api-provider-baremetal/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:155\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil\n\t/go/src/github.com/openshift/cluster-api-provider-baremetal/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:156\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/go/src/github.com/openshift/cluster-api-provider-baremetal/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133\nk8s.io/apimachinery/pkg/util/wait.Until\n\t/go/src/github.com/openshift/cluster-api-provider-baremetal/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:90"}     
```