### PR TITLE
ensure delete removes the link between machine and host

### DIFF
--- a/pkg/cloud/baremetal/actuators/machine/actuator_test.go
+++ b/pkg/cloud/baremetal/actuators/machine/actuator_test.go
@@ -872,6 +872,7 @@ func TestEnsureAnnotation(t *testing.T) {
 func TestDelete(t *testing.T) {
 	scheme := runtime.NewScheme()
 	bmoapis.AddToScheme(scheme)
+	machinev1beta1.AddToScheme(scheme)
 
 	testCases := []struct {
 		CaseName            string
@@ -1171,6 +1172,7 @@ func TestDelete(t *testing.T) {
 		if tc.Host != nil {
 			c.Create(context.TODO(), tc.Host)
 		}
+		c.Create(context.TODO(), &(tc.Machine))
 		actuator, err := NewActuator(ActuatorParams{
 			Client: c,
 		})


### PR DESCRIPTION
We were not removing the host annotation from the machine, which made
it appear to always be deleting. This change reorganizes the Delete()
function in the actuator to ensure that all of the progressive steps
of deprovisioning the host and then removing both links between the
machine and host are handled.

https://bugzilla.redhat.com/show_bug.cgi?id=1855823