### PR TITLE
remove machine finalizer from host when deleting machine

### DIFF
--- a/pkg/cloud/baremetal/actuators/machine/actuator.go
+++ b/pkg/cloud/baremetal/actuators/machine/actuator.go
@@ -219,6 +219,11 @@ func (a *Actuator) Delete(ctx context.Context, machine *machinev1beta1.Machine) 
 
 	log.Printf("clearing consumer reference for host %v", host.Name)
 	host.Spec.ConsumerRef = nil
+	if utils.StringInList(host.Finalizers, machinev1beta1.MachineFinalizer) {
+		log.Printf("clearing machine finalizer for host %v", host.Name)
+		host.Finalizers = utils.FilterStringFromList(
+			host.Finalizers, machinev1beta1.MachineFinalizer)
+	}
 	err = a.client.Update(ctx, host)
 	if err != nil && !errors.IsNotFound(err) {
 		return err


### PR DESCRIPTION
When a Machine is deleted, any host it was using should have all
associations with Machines removed. We were removing the explicit
links to the machine, but not the finalizer that the machine
controller added. This change removes the finalizer so that hosts that
are no longer being consumed by a machine can be deleted.

https://bugzilla.redhat.com/show_bug.cgi?id=1837505