### PR TITLE
ignore externally provisioned hosts when looking for candidates

### DIFF
--- a/pkg/cloud/baremetal/actuators/machine/actuator.go
+++ b/pkg/cloud/baremetal/actuators/machine/actuator.go
@@ -452,6 +452,12 @@ func (a *Actuator) chooseHost(ctx context.Context, machine *machinev1beta1.Machi
 			// the host has some sort of error
 			continue
 		}
+		if host.Spec.ExternallyProvisioned {
+			// the host was provisioned by something else, we should
+			// not overwrite it
+			continue
+		}
+
 		if labelSelector.Matches(labels.Set(host.ObjectMeta.Labels)) {
 			log.Printf("Host '%s' matched hostSelector for Machine '%s'",
 				host.Name, machine.Name)

--- a/pkg/cloud/baremetal/actuators/machine/actuator.go
+++ b/pkg/cloud/baremetal/actuators/machine/actuator.go
@@ -448,6 +448,10 @@ func (a *Actuator) chooseHost(ctx context.Context, machine *machinev1beta1.Machi
 			// the host is being deleted
 			continue
 		}
+		if host.Status.Provisioning.State != bmh.StateReady {
+			// the host has not completed introspection or has an error
+			continue
+		}
 		if host.Status.ErrorMessage != "" {
 			// the host has some sort of error
 			continue

--- a/pkg/cloud/baremetal/actuators/machine/actuator_test.go
+++ b/pkg/cloud/baremetal/actuators/machine/actuator_test.go
@@ -85,7 +85,7 @@ func TestChooseHost(t *testing.T) {
 			ErrorMessage: "this host is discovered and not usable",
 		},
 	}
-	host_with_label := bmh.BareMetalHost{
+	hostWithLabel := bmh.BareMetalHost{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "host_with_label",
 			Namespace: "myns",
@@ -208,8 +208,8 @@ func TestChooseHost(t *testing.T) {
 					ProviderSpec: providerSpec,
 				},
 			},
-			Hosts:            []runtime.Object{&host_with_label},
-			ExpectedHostName: host_with_label.Name,
+			Hosts:            []runtime.Object{&hostWithLabel},
+			ExpectedHostName: hostWithLabel.Name,
 			Config:           config,
 		},
 		{
@@ -227,8 +227,8 @@ func TestChooseHost(t *testing.T) {
 					ProviderSpec: providerSpec2,
 				},
 			},
-			Hosts:            []runtime.Object{&host2, &host_with_label},
-			ExpectedHostName: host_with_label.Name,
+			Hosts:            []runtime.Object{&host2, &hostWithLabel},
+			ExpectedHostName: hostWithLabel.Name,
 			Config:           config2,
 		},
 		{
@@ -246,7 +246,7 @@ func TestChooseHost(t *testing.T) {
 					ProviderSpec: providerSpec3,
 				},
 			},
-			Hosts:            []runtime.Object{&host2, &host_with_label},
+			Hosts:            []runtime.Object{&host2, &hostWithLabel},
 			ExpectedHostName: "",
 			Config:           config3,
 		},
@@ -265,8 +265,8 @@ func TestChooseHost(t *testing.T) {
 					ProviderSpec: providerSpec4,
 				},
 			},
-			Hosts:            []runtime.Object{&host2, &host_with_label},
-			ExpectedHostName: host_with_label.Name,
+			Hosts:            []runtime.Object{&host2, &hostWithLabel},
+			ExpectedHostName: hostWithLabel.Name,
 			Config:           config4,
 		},
 		{
@@ -303,7 +303,7 @@ func TestChooseHost(t *testing.T) {
 					ProviderSpec: providerSpec5,
 				},
 			},
-			Hosts:            []runtime.Object{&host2, &host_with_label},
+			Hosts:            []runtime.Object{&host2, &hostWithLabel},
 			ExpectedHostName: "",
 			Config:           config5,
 		},

--- a/pkg/cloud/baremetal/actuators/machine/actuator_test.go
+++ b/pkg/cloud/baremetal/actuators/machine/actuator_test.go
@@ -49,11 +49,21 @@ func TestChooseHost(t *testing.T) {
 				APIVersion: machinev1beta1.SchemeGroupVersion.String(),
 			},
 		},
+		Status: bmh.BareMetalHostStatus{
+			Provisioning: bmh.ProvisionStatus{
+				State: bmh.StateReady,
+			},
+		},
 	}
 	host2 := bmh.BareMetalHost{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "host2",
 			Namespace: "myns",
+		},
+		Status: bmh.BareMetalHostStatus{
+			Provisioning: bmh.ProvisionStatus{
+				State: bmh.StateReady,
+			},
 		},
 	}
 	host3 := bmh.BareMetalHost{
@@ -69,11 +79,21 @@ func TestChooseHost(t *testing.T) {
 				APIVersion: machinev1beta1.SchemeGroupVersion.String(),
 			},
 		},
+		Status: bmh.BareMetalHostStatus{
+			Provisioning: bmh.ProvisionStatus{
+				State: bmh.StateReady,
+			},
+		},
 	}
 	host4 := bmh.BareMetalHost{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "host4",
 			Namespace: "someotherns",
+		},
+		Status: bmh.BareMetalHostStatus{
+			Provisioning: bmh.ProvisionStatus{
+				State: bmh.StateReady,
+			},
 		},
 	}
 	discoveredHost := bmh.BareMetalHost{
@@ -83,6 +103,9 @@ func TestChooseHost(t *testing.T) {
 		},
 		Status: bmh.BareMetalHostStatus{
 			ErrorMessage: "this host is discovered and not usable",
+			Provisioning: bmh.ProvisionStatus{
+				State: bmh.StateRegistrationError,
+			},
 		},
 	}
 	hostWithLabel := bmh.BareMetalHost{
@@ -90,6 +113,11 @@ func TestChooseHost(t *testing.T) {
 			Name:      "host_with_label",
 			Namespace: "myns",
 			Labels:    map[string]string{"key1": "value1"},
+		},
+		Status: bmh.BareMetalHostStatus{
+			Provisioning: bmh.ProvisionStatus{
+				State: bmh.StateReady,
+			},
 		},
 	}
 	externallyProvisionedHost := bmh.BareMetalHost{
@@ -99,6 +127,11 @@ func TestChooseHost(t *testing.T) {
 		},
 		Spec: bmh.BareMetalHostSpec{
 			ExternallyProvisioned: true,
+		},
+		Status: bmh.BareMetalHostStatus{
+			Provisioning: bmh.ProvisionStatus{
+				State: bmh.StateExternallyProvisioned,
+			},
 		},
 	}
 	externallyProvisionedAndConsumedHost := bmh.BareMetalHost{
@@ -113,6 +146,11 @@ func TestChooseHost(t *testing.T) {
 				Namespace:  "myns",
 				Kind:       "Machine",
 				APIVersion: machinev1beta1.SchemeGroupVersion.String(),
+			},
+		},
+		Status: bmh.BareMetalHostStatus{
+			Provisioning: bmh.ProvisionStatus{
+				State: bmh.StateExternallyProvisioned,
 			},
 		},
 	}


### PR DESCRIPTION
If a host was externally provisioned and not linked directly to the machine
for which we're looking for a host, we want to ignore it to avoid
overwriting whatever image is on the host now.

Includes a bit of code cleanup.

Fixes #91