### PR TITLE
Bug 1872080: Add Dockerfile.rhel to match build configuration in ocp-build-data

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,0 +1,13 @@
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-openshift-4.6 AS builder
+WORKDIR /go/src/github.com/openshift/cluster-api-provider-baremetal
+COPY . .
+RUN go build --mod=vendor -o machine-controller-manager ./cmd/manager
+
+FROM registry.svc.ci.openshift.org/ocp/4.6:base
+#RUN INSTALL_PKGS=" \
+#      libvirt-libs openssh-clients genisoimage \
+#      " && \
+#    yum install -y $INSTALL_PKGS && \
+#    rpm -V $INSTALL_PKGS && \
+#    yum clean all
+COPY --from=builder /go/src/github.com/openshift/cluster-api-provider-baremetal/machine-controller-manager /


### PR DESCRIPTION
This change adds a new Dockerfile.rhel file to control builds that
target rhel. It is inspired by the automatically generated patches which
ensure that build files match what is in the
[ocp-build-data repository](https://github.com/openshift/ocp-build-data/tree/openshift-4.6-rhel-8/images)
used for producing release artifacts.

After this change merges, the configuration files in
https://github.com/openshift/release/tree/master/ci-operator/config/openshift/cluster-api-provider-baremetal
and
https://github.com/openshift/ocp-build-data/blob/openshift-4.6/images/baremetal-machine-controller.yml
should be updated with the new dockerfile path.