### PR TITLE
Bug 1874618: add a make target to run only the unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,9 @@ all: test manager
 # Run tests
 test: generate fmt vet unit
 
-unit: manifests
+unit: manifests unit-test
+
+unit-test:
 	go test ./pkg/... ./cmd/... -coverprofile cover.out
 
 # Run against the configured Kubernetes cluster in ~/.kube/config


### PR DESCRIPTION
The existing unit target is useful for running tests locally by hand
because it ensures the manifests are up to date. This new target runs
only the tests, without building the manifests, and can be used in a
CI job where kustomize is not available to (a) run the tests and (b)
ensure that the output of kustomize is checked in to the repo.

See https://github.com/openshift/release/pull/11458

/assign @zaneb