### PR TITLE
Don't add a finalizer to the Node

### DIFF
--- a/pkg/cloud/baremetal/actuators/machine/actuator.go
+++ b/pkg/cloud/baremetal/actuators/machine/actuator.go
@@ -651,6 +651,11 @@ func (a *Actuator) handleNodeFinalizer(ctx context.Context, machine *machinev1be
 	}
 
 	if node.DeletionTimestamp.IsZero() {
+		// Do not add a finalizer if remediation has not been requested
+		if _, needsRemediation := machine.Annotations[externalRemediationAnnotation]; !needsRemediation {
+			return nil
+		}
+
 		if !utils.StringInList(node.Finalizers, nodeFinalizer) {
 			//add finalizer
 			node.Finalizers = append(node.Finalizers, nodeFinalizer)
@@ -939,7 +944,7 @@ func (a *Actuator) remediateIfNeeded(ctx context.Context, machine *machinev1beta
 	}
 
 	if _, needsRemediation := machine.Annotations[externalRemediationAnnotation]; !needsRemediation {
-		return nil
+		return a.removeNodeFinalizer(ctx, machine)
 	}
 
 	if _, poweredOffForRemediation := machine.Annotations[poweredOffForRemediation]; !poweredOffForRemediation {


### PR DESCRIPTION
The only time it is safe to add a finalizer to a Node is when there is a MachineHealthCheck maintaining the Machine. When a Machine is in the `failed` phase, the actuator is not called again until the Machine is deleted, so the actuator would be unable to remove the finalizer and the Node would be immortal until the Machine is deleted. (A MachineHealthCheck will ensure that any Machine in the failed phase will be deleted promptly.) Although we currently do not put baremetal Machines into the `failed` phase, this is planned for the near future in #113.

At the time the finalizer was implemented (in #67) it was thought potentially valuable to always capture the Node's metadata before it was deleted for any cause, so that it could always be restored. But in practice we only restore the data as part of the remediation process anyway. The theoretical future value of always capturing it before Node deletion does not outweigh the downside of being unable to delete the Node for a failed Machine at all.

During remediation we can capture the data we need without requiring a finalizer, so remove it altogether.