### PR TITLE
Fix typo in readme - annotation should exist on CR, not CRD

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ continue to get counted with the MachineSet that its Machine belongs to.
 
 MachineHealthCheck Controller in [Machine-API operator](https://github.com/openshift/machine-api-operator) is checking Node's health.
 If you would like to remediate unhealthy Machines you should add the following
-to MachineHealthCheck CRD:
+to MachineHealthCheck CR:
 ```
 annotations:
    machine.openshift.io/remediation-strategy: external-baremetal


### PR DESCRIPTION
To utilize power-cycle remediation, an admin should add that annotation to the MHC CR, and not the MHC CRD