### PR TITLE
Allow actuator.Exists() to find a host in the unmanaged state

### DIFF
--- a/pkg/cloud/baremetal/actuators/machine/actuator.go
+++ b/pkg/cloud/baremetal/actuators/machine/actuator.go
@@ -293,7 +293,7 @@ func (a *Actuator) Exists(ctx context.Context, machine *machinev1beta1.Machine) 
 	}
 
 	switch host.Status.Provisioning.State {
-	case bmh.StateProvisioned, bmh.StateExternallyProvisioned:
+	case bmh.StateProvisioned, bmh.StateExternallyProvisioned, bmh.StateUnmanaged:
 		log.Printf("Machine %v exists.", machine.Name)
 		return true, nil
 	case bmh.StateRegistering, bmh.StateRegistrationError, bmh.StatePowerManagementError:


### PR DESCRIPTION
This will enable the assisisted installer host to be linked