### PR TITLE
set consumerRef on externallyProvisioned hosts if the image is set

### DIFF
--- a/pkg/cloud/baremetal/actuators/machine/actuator.go
+++ b/pkg/cloud/baremetal/actuators/machine/actuator.go
@@ -489,9 +489,9 @@ func (a *Actuator) chooseHost(ctx context.Context, machine *machinev1beta1.Machi
 			// the host has some sort of error
 			continue
 		}
-		if host.Spec.ExternallyProvisioned {
-			// the host was provisioned by something else, we should
-			// not overwrite it
+		if host.Spec.ExternallyProvisioned && host.Spec.Image == nil {
+			// The host should only be provisioned by something else, we should
+			// not overwrite it. But we can associate the new machine to it.
 			continue
 		}
 


### PR DESCRIPTION
We only start provisioning if image is nil, otherwise we assume it is
provisioned and associate the machine to the bmh using the consumerRef.

If we don't do this, then it forces anyone doing externallyProvisioned hosts
to replicate this code.