### PR TITLE
Bug 1975296: Handle the case that external remediation annotation is removed from a recovered machine

### DIFF
--- a/pkg/cloud/baremetal/actuators/machine/actuator.go
+++ b/pkg/cloud/baremetal/actuators/machine/actuator.go
@@ -1111,7 +1111,7 @@ func (a *Actuator) remediateIfNeeded(ctx context.Context, machine *machinev1beta
 		}
 	}
 
-	if _, poweredOffForRemediation := machine.Annotations[poweredOffForRemediation]; !poweredOffForRemediation {
+	if _, poweredOffForRemediationExists := machine.Annotations[poweredOffForRemediation]; !poweredOffForRemediationExists {
 		if !hasPowerOffRequestAnnotation(baremetalhost) {
 			log.Printf("Found an unhealthy machine, requesting power off. Machine name: %s", machine.Name)
 			return a.requestPowerOff(ctx, baremetalhost)

--- a/pkg/cloud/baremetal/actuators/machine/actuator.go
+++ b/pkg/cloud/baremetal/actuators/machine/actuator.go
@@ -1084,12 +1084,14 @@ func (a *Actuator) getNodeByMachine(ctx context.Context, machine *machinev1beta1
 remediateIfNeeded will try to remediate unhealthy machines (annotated by MHC) by power-cycle the host
 The full remediation flow is:
 1) Power off the host
-2) Add poweredOffForRemediation annotation to the unhealthy Machine
-3) Delete the node
-4) Power on the host
-5) Wait for the node the come up (by waiting for the node to be registered in the cluster)
-6) Restore node's annotations and labels
-7) Remove poweredOffForRemediation annotation, MAO's machine unhealthy annotation and annotations/labels backup
+2) Store node's annotations and labels
+3) Delete node
+4) Add poweredOffForRemediation annotation to the unhealthy Machine
+5) Power on the host
+6) Wait for the node the come up (by waiting for the node to be registered in the cluster)
+7) If the node doesn't come up after some time, and the host can be reprovisioned, delete the machine
+8) Restore node's annotations and labels
+9) Remove all remediation related annotations from the machine
 */
 func (a *Actuator) remediateIfNeeded(ctx context.Context, machine *machinev1beta1.Machine, baremetalhost *bmh.BareMetalHost) error {
 	if len(machine.Annotations) == 0 {

--- a/pkg/cloud/baremetal/actuators/machine/actuator.go
+++ b/pkg/cloud/baremetal/actuators/machine/actuator.go
@@ -1119,7 +1119,12 @@ func (a *Actuator) remediateIfNeeded(ctx context.Context, machine *machinev1beta
 
 		// We want to cancel a remediation, if nothing happened yet: power off was requested, but not executed yet.
 		if powerOffRequestExists && baremetalhost.Status.PoweredOn {
-			return a.requestPowerOn(ctx, machine, baremetalhost)
+			err := a.requestPowerOn(ctx, machine, baremetalhost)
+			// no need to requeue
+			if _, ok := err.(*machineapierrors.RequeueAfterError); ok {
+				return nil
+			}
+			return err
 		}
 
 		// In all other cases: there is an ongoing remediation, which should not be interrupted


### PR DESCRIPTION
It can happen that an unhealthy machine with external remediation annotation got healthy, and the external remediation annotation was removed by the MHC controller, before remediation finished or even started (e.g. the metal3 pod is not running, but machine was rebooted manually). In this case stop remediation, if possible.

This is one part of the fix for bz 1975296, the other one is in MHC controller, which will remove the external remediation annotation for healthy machines (https://github.com/openshift/machine-api-operator/pull/891)