### PR TITLE
Don't wait for status on externally-provisioned hosts

### DIFF
--- a/pkg/cloud/baremetal/actuators/machine/actuator.go
+++ b/pkg/cloud/baremetal/actuators/machine/actuator.go
@@ -312,6 +312,13 @@ func (a *Actuator) Exists(ctx context.Context, machine *machinev1beta1.Machine) 
 	case bmh.StateRegistering:
 		log.Printf("Machine %v exists but Host is not manageable.", machine.Name)
 		return true, nil
+	case "":
+		// Handle control plane nodes even if Metal³ is not running
+		if host.Spec.ExternallyProvisioned {
+			log.Printf("Machine %v exists (externally provisioned).", machine.Name)
+			return true, nil
+		}
+		fallthrough
 	default:
 		log.Printf("Machine %v does not have provisioned Host (%v is %s).",
 			machine.Name, host.Name, host.Status.Provisioning.State)


### PR DESCRIPTION
If a host has the ExternallyProvisioned spec flag set then it is already provisioned, so we can say that the Machine exists. Previously, we waited for the provisioning status to reach the "externally provisioned" state, but this requires the baremetal-operator to be running to reconcile the host.

Since there is nothing for the baremetal-operator to do here, we do not need to wait and can just report that the Machine exists (thus moving from the Create to the Update part of the reconciliation).

This should prevent a failure to start metal³ effectively blocking other things like linking control plane Nodes to Machines.

When metal³ does start, the only states that the host can go through are unmanaged, registering, and externally provisioned. All of these already result in returning true from Exists(), so there is no way for a previously existing host to appear to temporarily disappear.