### PR TITLE
NO-ISSUE: Log when applying updates to BareMetalHost

### DIFF
--- a/pkg/cloud/baremetal/actuators/machine/actuator.go
+++ b/pkg/cloud/baremetal/actuators/machine/actuator.go
@@ -592,6 +592,8 @@ func (a *Actuator) provisionHost(ctx context.Context, host *bmh.BareMetalHost,
 	if equality.Semantic.DeepEqual(originalHost, host) {
 		return nil
 	}
+
+	log.Printf("updating host %v with deployment information", host.Name)
 	if err := a.client.Update(ctx, host); err != nil {
 		return gherrors.Wrap(err, "failed to provision host")
 	}


### PR DESCRIPTION
It's important to know to be able to trace what is updating BMH's.
In all other places, we do log when there is a diff, but not for hosts.
