### PR TITLE
Extend metal3remediation aggregation role

### DIFF
--- a/manifests/0000_30_machine-api-operator_10_metal3remediation_aggregation_role.yaml
+++ b/manifests/0000_30_machine-api-operator_10_metal3remediation_aggregation_role.yaml
@@ -16,6 +16,8 @@ rules:
       - metal3remediationtemplates
     verbs:
       - get
+      - list
+      - watch
   - apiGroups:
       - infrastructure.cluster.x-k8s.io
     resources:
@@ -23,6 +25,9 @@ rules:
     verbs:
       - get
       - list
+      - watch
       - create
+      - update
+      - patch
       - delete
 


### PR DESCRIPTION
Hi, we (medik8s) need to have some mofications to the metal3 remediation aggregation role, which is picked up by our Node Healthcheck Operator. This is no extension from "read" to "write", so it's nothing critical.

- Node Healthcheck controller is going to watch templates, in order to update its own status in case a template is deleted
- NHC is also watching the remediation CRs, in order to update its own status when the CR is finally deleted after the metal3 controller removed the finalizer
- NHC is updating/patching CRs with an annotation (unused by metal3 controller, but we'd like to prevent error messages in NHC controller)

Would be awesome to get this backported up to 4.14, what's the process for this please?

ECOPROJECT-1822
ECOPROJECT-1857
