### PR TITLE
Don't set errorMessage when no BareMetalHost is available

### DIFF
--- a/pkg/cloud/baremetal/actuators/machine/actuator.go
+++ b/pkg/cloud/baremetal/actuators/machine/actuator.go
@@ -121,16 +121,7 @@ func (a *Actuator) Create(ctx context.Context, machine *machinev1beta1.Machine) 
 			return err
 		}
 		if host == nil {
-			errorReason := machinev1beta1.InsufficientResourcesMachineError
-			msg := "No available BareMetalHost found"
-			log.Printf("%s", msg)
-			if machine.Status.ErrorReason == nil || *machine.Status.ErrorReason != errorReason {
-				machine.Status.ErrorReason = &errorReason
-				machine.Status.ErrorMessage = &msg
-				if err := a.client.Status().Update(ctx, machine); err != nil {
-					return gherrors.Wrap(err, "failed to set insufficient resources error")
-				}
-			}
+			log.Printf("No available host found. Requeuing.")
 			return &machineapierrors.RequeueAfterError{RequeueAfter: requeueAfter}
 		}
 		log.Printf("Associating machine %s with host %s", machine.Name, host.Name)


### PR DESCRIPTION
When no available BMH can be chosen for a Machine, this provider was setting errorMessage/errorReason (InsufficientResources) on the Machine status. However, the Cluster API InfraMachine contract defines failureMessage/ failureReason as fields for terminal (unrecoverable) failures, not for transient conditions expected to resolve automatically: https://cluster-api.sigs.k8s.io/developer/providers/contracts/infra-machine The OpenShift Machine API similarly states that errorMessage should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time:
https://github.com/openshift/api/blob/b1cc68a860b328ff9f53c948d7f244d7dc93f902/machine/v1beta1/types_machine.go#L365

Cluster Autoscaler treats a Machine with errorMessage set as permanently failed and abandons the scale-out almost immediately. This makes it impossible to provision BMHs on demand after CA makes a scale-out decision, as the Machine is deleted before the BMH can be prepared.

The upstream metal3 implementation treats this as a transient condition by returning a requeue error without setting failureMessage: https://github.com/metal3-io/cluster-api-provider-metal3/blob/0664954f8e6ba16736f9230a641184876a8935a4/baremetal/metal3machine_manager.go#L465

The original motivation for setting errorMessage (introduced in #113 to prioritize deletion of Machines without a ready BMH) has since been superseded by a separate fix in machine-api-operator (openshift/machine-api-operator#772), so removing it here has no impact on deletion behavior.

Fixes: https://github.com/openshift/cluster-api-provider-baremetal/issues/257

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved machine provisioning retries when no suitable bare metal host is available.
  * Machines now requeue automatically instead of immediately reporting an insufficient resources error, reducing noisy failure states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->