### PR TITLE
OCPBUGS-112338: Prevent Machine from claiming a second BareMetalHost

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -214,6 +214,9 @@ func main() {
 
 	machineActuator, err := machine.NewActuator(machine.ActuatorParams{
 		Client: mgr.GetClient(),
+		// Used only after a Machine annotation Update conflict, to see the
+		// annotation already written by another reconcile.
+		APIReader: mgr.GetAPIReader(),
 	})
 	if err != nil {
 		panic(err)

--- a/pkg/cloud/baremetal/actuators/machine/actuator.go
+++ b/pkg/cloud/baremetal/actuators/machine/actuator.go
@@ -73,18 +73,23 @@ const (
 
 // Actuator is responsible for performing machine reconciliation
 type Actuator struct {
-	client client.Client
+	client    client.Client
+	apiReader client.Reader
 }
 
 // ActuatorParams holds parameter information for Actuator
 type ActuatorParams struct {
 	Client client.Client
+	// APIReader is used only to re-read a Machine after an annotation Update
+	// conflict. Host lookups always use Client (the informer cache).
+	APIReader client.Reader
 }
 
 // NewActuator creates a new Actuator
 func NewActuator(params ActuatorParams) (*Actuator, error) {
 	return &Actuator{
-		client: params.Client,
+		client:    params.Client,
+		apiReader: params.APIReader,
 	}, nil
 }
 
@@ -390,31 +395,66 @@ func getHostKey(ctx context.Context, machine *machinev1beta1.Machine) (provider 
 	return
 }
 
-// getHost gets the associated host by looking for an annotation on the machine
-// that contains a reference to the host. Returns nil if not found. Assumes the
-// host is in the same namespace as the machine.
+// getHost gets the associated host by looking for an annotation or ProviderID
+// on the machine that contains a reference to the host. If that lookup fails,
+// it falls back to a BareMetalHost whose ConsumerRef matches this Machine.
+// Returns nil if not found.
 func (a *Actuator) getHost(ctx context.Context, machine *machinev1beta1.Machine) (*bmh.BareMetalHost, error) {
 	provider, key, uid, err := getHostKey(ctx, machine)
 	if err != nil {
 		log.Printf("Failed to get Host key: %v", err)
 		return nil, err
 	}
-	if key == nil {
+	if key != nil {
+		host := bmh.BareMetalHost{}
+		err = a.client.Get(ctx, *key, &host)
+		if err == nil && (uid == nil || host.UID == *uid) {
+			return &host, nil
+		}
+		if err != nil && !errors.IsNotFound(err) {
+			return nil, err
+		}
+		if errors.IsNotFound(err) {
+			log.Printf("Linked host %s not found", provider)
+		}
+	}
+
+	return a.hostByConsumerRef(ctx, machine)
+}
+
+// hostByConsumerRef lists BareMetalHosts and returns one whose ConsumerRef
+// matches this Machine. This covers the window after provisionHost() writes
+// ConsumerRef but before ensureAnnotation() is observed on the Machine.
+func (a *Actuator) hostByConsumerRef(ctx context.Context, machine *machinev1beta1.Machine) (*bmh.BareMetalHost, error) {
+	if machine.Name == "" {
 		return nil, nil
 	}
 
-	host := bmh.BareMetalHost{}
-	err = a.client.Get(ctx, *key, &host)
-	if errors.IsNotFound(err) {
-		log.Printf("Linked host %s not found", provider)
-		return nil, nil
-	} else if err != nil {
-		return nil, err
-	} else if uid != nil && host.UID != *uid {
-		// Host object has been replaced by a new one
-		return nil, nil
+	hosts := bmh.BareMetalHostList{}
+	opts := &client.ListOptions{
+		Namespace: machine.Namespace,
 	}
-	return &host, nil
+	err := a.client.List(ctx, &hosts, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	var found *bmh.BareMetalHost
+	for i := range hosts.Items {
+		if !consumerRefMatches(hosts.Items[i].Spec.ConsumerRef, machine) {
+			continue
+		}
+		if found != nil {
+			log.Printf("Machine %s has ConsumerRef on multiple hosts (%s and %s); using %s",
+				machine.Name, found.Name, hosts.Items[i].Name, found.Name)
+			break
+		}
+		found = &hosts.Items[i]
+	}
+	if found != nil {
+		log.Printf("found host %s by ConsumerRef for machine %s", found.Name, machine.Name)
+	}
+	return found, nil
 }
 
 // SelectorFromProviderSpec returns a selector that can be used to determine if
@@ -596,6 +636,13 @@ func (a *Actuator) provisionHost(ctx context.Context, host *bmh.BareMetalHost,
 
 	log.Printf("updating host %v with deployment information", host.Name)
 	if err := a.client.Update(ctx, host); err != nil {
+		// Update enforces resourceVersion. A conflict means another writer
+		// changed this BareMetalHost (typically another Machine claiming it).
+		// Retry on the next reconcile instead of overwriting with Patch.
+		if errors.IsConflict(err) {
+			log.Printf("host %s was modified, requeuing", host.Name)
+			return &machineapierrors.RequeueAfterError{RequeueAfter: requeueAfter}
+		}
 		return gherrors.Wrap(err, "failed to provision host")
 	}
 	return nil
@@ -671,6 +718,9 @@ func (a *Actuator) ensureAnnotation(ctx context.Context, machine *machinev1beta1
 
 	machine.ObjectMeta.SetAnnotations(annotations)
 	if err := a.client.Update(ctx, machine); err != nil {
+		if errors.IsConflict(err) {
+			return a.handleAnnotationConflict(ctx, machine, host, hostKey)
+		}
 		return gherrors.Wrap(err, "failed to update machine annotation")
 	}
 
@@ -679,6 +729,42 @@ func (a *Actuator) ensureAnnotation(ctx context.Context, machine *machinev1beta1
 	// complete. Use a delay so that we don't requeue before the annotation change
 	// is observed.
 	return &machineapierrors.RequeueAfterError{RequeueAfter: requeueAfter}
+}
+
+// handleAnnotationConflict recovers from a Machine Update conflict. That is the
+// "object has been modified" signal Update gives when our resourceVersion is
+// stale. If the Machine is already bound to a different BareMetalHost, release
+// the host we just claimed so this Machine does not consume two hosts.
+func (a *Actuator) handleAnnotationConflict(ctx context.Context, machine *machinev1beta1.Machine, host *bmh.BareMetalHost, hostKey string) error {
+	latest := &machinev1beta1.Machine{}
+	key := client.ObjectKey{Namespace: machine.Namespace, Name: machine.Name}
+	if err := a.machineReader().Get(ctx, key, latest); err != nil {
+		return gherrors.Wrap(err, "failed to re-read machine after annotation conflict")
+	}
+
+	current := ""
+	if latest.Annotations != nil {
+		current = latest.Annotations[HostAnnotation]
+	}
+	if current != "" && current != hostKey {
+		log.Printf("machine %s is already annotated to %s, releasing host %s",
+			machine.Name, current, host.Name)
+		if err := a.releaseHost(ctx, host, machine); err != nil {
+			return err
+		}
+	}
+
+	return &machineapierrors.RequeueAfterError{RequeueAfter: requeueAfter}
+}
+
+// machineReader returns a reader for the Machine after an Update conflict.
+// APIReader is used when set so we see the annotation another reconcile already
+// wrote, rather than a stale informer copy of the same Machine.
+func (a *Actuator) machineReader() client.Reader {
+	if a.apiReader != nil {
+		return a.apiReader
+	}
+	return a.client
 }
 
 // providerIDForHost returns a provider ID representing a given BareMetalHost

--- a/pkg/cloud/baremetal/actuators/machine/actuator_test.go
+++ b/pkg/cloud/baremetal/actuators/machine/actuator_test.go
@@ -694,8 +694,19 @@ func TestExists(t *testing.T) {
 					},
 				},
 			},
-			Expected:    false,
-			FailMessage: "found host even though annotation value incorrect",
+			Expected:    true,
+			FailMessage: "failed to find host by ConsumerRef after stale annotation",
+		},
+		{
+			Client: c,
+			Machine: machinev1beta1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      machineName,
+					Namespace: "myns",
+				},
+			},
+			Expected:    true,
+			FailMessage: "failed to find host by ConsumerRef when annotation is missing",
 		},
 		{
 			Client:      c,
@@ -734,6 +745,22 @@ func TestGetHost(t *testing.T) {
 	}
 	c := fakeclient.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(&host).Build()
 
+	hostWithConsumer := bmh.BareMetalHost{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "consumedhost",
+			Namespace: "myns",
+		},
+		Spec: bmh.BareMetalHostSpec{
+			ConsumerRef: &corev1.ObjectReference{
+				Name:       "machine1",
+				Namespace:  "myns",
+				Kind:       "Machine",
+				APIVersion: machinev1beta1.SchemeGroupVersion.String(),
+			},
+		},
+	}
+	cConsumed := fakeclient.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(&hostWithConsumer).Build()
+
 	testCases := []struct {
 		Client        client.Client
 		Machine       machinev1beta1.Machine
@@ -770,6 +797,42 @@ func TestGetHost(t *testing.T) {
 			ExpectPresent: false,
 			FailMessage:   "found host even though annotation not present",
 		},
+		{
+			Client: cConsumed,
+			Machine: machinev1beta1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "machine1",
+					Namespace: "myns",
+				},
+			},
+			ExpectPresent: true,
+			FailMessage:   "did not find host by ConsumerRef when annotation is missing",
+		},
+		{
+			Client: cConsumed,
+			Machine: machinev1beta1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "machine1",
+					Namespace: "myns",
+					Annotations: map[string]string{
+						HostAnnotation: "myns/wrong",
+					},
+				},
+			},
+			ExpectPresent: true,
+			FailMessage:   "did not find host by ConsumerRef after stale annotation",
+		},
+		{
+			Client: cConsumed,
+			Machine: machinev1beta1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "othermachine",
+					Namespace: "myns",
+				},
+			},
+			ExpectPresent: false,
+			FailMessage:   "found host whose ConsumerRef belongs to a different machine",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -787,6 +850,204 @@ func TestGetHost(t *testing.T) {
 		if (result != nil) != tc.ExpectPresent {
 			t.Error(tc.FailMessage)
 		}
+	}
+}
+
+func TestCreateReusesHostClaimedByConsumerRef(t *testing.T) {
+	scheme := runtime.NewScheme()
+	bmoapis.AddToScheme(scheme)
+	machinev1beta1.AddToScheme(scheme)
+
+	config, _ := newConfig(t, "", map[string]string{}, []bmv1alpha1.HostSelectorRequirement{})
+	raw, err := json.Marshal(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	machine := machinev1beta1.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "machine1",
+			Namespace: "myns",
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Machine",
+			APIVersion: machinev1beta1.SchemeGroupVersion.String(),
+		},
+		Spec: machinev1beta1.MachineSpec{
+			ProviderSpec: machinev1beta1.ProviderSpec{
+				Value: &runtime.RawExtension{Raw: raw},
+			},
+		},
+	}
+	consumed := bmh.BareMetalHost{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "host3",
+			Namespace: "myns",
+		},
+		Spec: bmh.BareMetalHostSpec{
+			ConsumerRef: &corev1.ObjectReference{
+				Name:       "machine1",
+				Namespace:  "myns",
+				Kind:       "Machine",
+				APIVersion: machinev1beta1.SchemeGroupVersion.String(),
+			},
+		},
+		Status: bmh.BareMetalHostStatus{
+			Provisioning: bmh.ProvisionStatus{
+				State: bmh.StateReady,
+			},
+		},
+	}
+	available := bmh.BareMetalHost{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "host2",
+			Namespace: "myns",
+		},
+		Status: bmh.BareMetalHostStatus{
+			Provisioning: bmh.ProvisionStatus{
+				State: bmh.StateReady,
+			},
+		},
+	}
+
+	c := fakeclient.NewClientBuilder().
+		WithScheme(scheme).
+		WithRuntimeObjects(machine.DeepCopy(), consumed.DeepCopy(), available.DeepCopy()).
+		Build()
+
+	actuator, err := NewActuator(ActuatorParams{
+		Client: c,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	created := &machinev1beta1.Machine{}
+	if err := c.Get(context.TODO(), client.ObjectKey{Namespace: "myns", Name: "machine1"}, created); err != nil {
+		t.Fatal(err)
+	}
+
+	err = actuator.Create(context.TODO(), created)
+	expectRequeueAfterError(err, t)
+
+	gotConsumed := bmh.BareMetalHost{}
+	if err := c.Get(context.TODO(), client.ObjectKey{Namespace: "myns", Name: "host3"}, &gotConsumed); err != nil {
+		t.Fatal(err)
+	}
+	if !consumerRefMatches(gotConsumed.Spec.ConsumerRef, &machine) {
+		t.Error("expected host3 to remain consumed by machine1")
+	}
+
+	gotAvailable := bmh.BareMetalHost{}
+	if err := c.Get(context.TODO(), client.ObjectKey{Namespace: "myns", Name: "host2"}, &gotAvailable); err != nil {
+		t.Fatal(err)
+	}
+	if gotAvailable.Spec.ConsumerRef != nil {
+		t.Errorf("available host was claimed as %v; expected it to stay free", gotAvailable.Spec.ConsumerRef)
+	}
+
+	gotMachine := machinev1beta1.Machine{}
+	if err := c.Get(context.TODO(), client.ObjectKey{Namespace: "myns", Name: "machine1"}, &gotMachine); err != nil {
+		t.Fatal(err)
+	}
+	if gotMachine.Annotations[HostAnnotation] != "myns/host3" {
+		t.Errorf("expected annotation myns/host3, got %q", gotMachine.Annotations[HostAnnotation])
+	}
+}
+
+func TestCreateAnnotationConflictReleasesExtraHost(t *testing.T) {
+	scheme := runtime.NewScheme()
+	bmoapis.AddToScheme(scheme)
+	machinev1beta1.AddToScheme(scheme)
+
+	config, _ := newConfig(t, "", map[string]string{}, []bmv1alpha1.HostSelectorRequirement{})
+	raw, err := json.Marshal(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	machine := machinev1beta1.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "machine1",
+			Namespace: "myns",
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Machine",
+			APIVersion: machinev1beta1.SchemeGroupVersion.String(),
+		},
+		Spec: machinev1beta1.MachineSpec{
+			ProviderSpec: machinev1beta1.ProviderSpec{
+				Value: &runtime.RawExtension{Raw: raw},
+			},
+		},
+	}
+	// host3 is already recorded on the Machine but is not selectable, so a
+	// stale Create() without the annotation will pick host2 instead.
+	host3 := bmh.BareMetalHost{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "host3",
+			Namespace: "myns",
+		},
+		Status: bmh.BareMetalHostStatus{
+			Provisioning: bmh.ProvisionStatus{
+				State: bmh.StateProvisioning,
+			},
+		},
+	}
+	host2 := bmh.BareMetalHost{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "host2",
+			Namespace: "myns",
+		},
+		Status: bmh.BareMetalHostStatus{
+			Provisioning: bmh.ProvisionStatus{
+				State: bmh.StateReady,
+			},
+		},
+	}
+
+	c := fakeclient.NewClientBuilder().
+		WithScheme(scheme).
+		WithRuntimeObjects(machine.DeepCopy(), host2.DeepCopy(), host3.DeepCopy()).
+		Build()
+
+	stale := &machinev1beta1.Machine{}
+	if err := c.Get(context.TODO(), client.ObjectKey{Namespace: "myns", Name: "machine1"}, stale); err != nil {
+		t.Fatal(err)
+	}
+
+	current := stale.DeepCopy()
+	current.Annotations = map[string]string{
+		HostAnnotation: "myns/host3",
+	}
+	if err := c.Update(context.TODO(), current); err != nil {
+		t.Fatal(err)
+	}
+
+	actuator, err := NewActuator(ActuatorParams{
+		Client: c,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = actuator.Create(context.TODO(), stale)
+	expectRequeueAfterError(err, t)
+
+	gotHost2 := bmh.BareMetalHost{}
+	if err := c.Get(context.TODO(), client.ObjectKey{Namespace: "myns", Name: "host2"}, &gotHost2); err != nil {
+		t.Fatal(err)
+	}
+	if gotHost2.Spec.ConsumerRef != nil {
+		t.Errorf("stale Create claimed host2 as %v; expected it to be released", gotHost2.Spec.ConsumerRef)
+	}
+
+	gotMachine := machinev1beta1.Machine{}
+	if err := c.Get(context.TODO(), client.ObjectKey{Namespace: "myns", Name: "machine1"}, &gotMachine); err != nil {
+		t.Fatal(err)
+	}
+	if gotMachine.Annotations[HostAnnotation] != "myns/host3" {
+		t.Errorf("expected annotation myns/host3, got %q", gotMachine.Annotations[HostAnnotation])
 	}
 }
 


### PR DESCRIPTION
Reuse an existing consumerRef before choosing a new host, list BMHs from the API server, and serialize host claims so a stale cache cannot leave a worker Machine without a host.

Assisted-By: Claude Opus 4.6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved machine provisioning when host metadata is missing or outdated by matching machines to their associated hosts more reliably.
  * Prevented concurrent provisioning requests from claiming the same host.
  * Reused an existing host already claimed by the requesting machine instead of allocating another one.
  * Ignored hosts linked to different machines, reducing incorrect host assignments.
  * Improved recovery from update conflicts by refreshing current machine and host information, releasing unintended claims, and retrying provisioning safely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->